### PR TITLE
refactor: added default destructor to smart device

### DIFF
--- a/src/include/smart_device.h
+++ b/src/include/smart_device.h
@@ -31,6 +31,14 @@ public:
 
   virtual void handle_update(QJsonObject const  &payload) = 0;
 
+  //For memory we specify the virtual destructure to ensure that derived classes are cleaned
+  // when using polymorphism 
+  virtual ~SmartDevice() = default;
+
+  //but since we defined the destructor we need to also explicitly create the copy/move constructors
+  // this would adhere to the rule of 5 since now the compiler will NOT create them by default
+  Q_DISABLE_COPY_MOVE(SmartDevice)
+
 signals:
 
   void state_changed(bool state);


### PR DESCRIPTION
Added default destructor to prevent polymorphic memory leaks 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved lifecycle management for the smart device component to ensure proper cleanup of derived objects.
  * Made object-copying and -moving explicit to prevent accidental copies/moves and strengthen ownership semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->