### PR TITLE
refactor: used qPointers as far as possible

### DIFF
--- a/src/device_factory.cpp
+++ b/src/device_factory.cpp
@@ -59,7 +59,7 @@ std::optional<ColorTempRange> getColorTempRange(const QJsonObject &device) {
 // TODO: this will not work for devices I connect via MQTT exclusively, but I
 // can also just force those devices to use this format when they join the
 // network, maybe lol idk
-SmartDevice *create_device(QJsonObject const &data) {
+QPointer<SmartDevice> create_device(QJsonObject const &data) {
   auto friendly_name = data["friendly_name"].toString();
   auto ieee_address = data["ieee_address"].toString();
   auto model_id = data["model_id"].toString();

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -28,7 +28,7 @@ QList<QPointer<SmartDevice>> DeviceManager::devices() const {
   return m_devices.values();
 }
 
-QPointer<SmartDevice> DeviceManager::get_device(QString &id) const {
+QPointer<SmartDevice> DeviceManager::get_device(const QString &id) const {
   return m_devices.value(id, nullptr);
 }
 

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -24,7 +24,7 @@ DeviceManager::DeviceManager(QObject *parent)
   }
 }
 
-QList<SmartDevice *> DeviceManager::devices() const {
+QList<QPointer<SmartDevice>> DeviceManager::devices() const {
   return m_devices.values();
 }
 
@@ -39,7 +39,7 @@ void DeviceManager::handle_message(QString &topic, QJsonObject &payload) {
     return;
   }
 
-  for (auto *device : m_devices) {
+  for (const auto& device : m_devices) {
     QString device_topic = "zigbee2mqtt/" + device->friendly_name();
 
     if (topic == device_topic) {
@@ -86,7 +86,7 @@ void DeviceManager::add_new_device(QJsonArray const &payload) {
     }
   }
 
-  for (auto *device : m_devices) {
+  for (const auto& device : m_devices) {
     QString topic = "zigbee2mqtt/" + device->friendly_name() + "/get";
     QString payload = R"({"state": ""})";
     mqtt::message_ptr pubmsg =

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -28,7 +28,7 @@ QList<SmartDevice *> DeviceManager::devices() const {
   return m_devices.values();
 }
 
-SmartDevice *DeviceManager::get_device(QString &id) const {
+QPointer<SmartDevice> DeviceManager::get_device(QString &id) const {
   return m_devices.value(id, nullptr);
 }
 
@@ -67,7 +67,7 @@ void DeviceManager::add_new_device(QJsonArray const &payload) {
       continue;
     }
 
-    auto *device = DeviceFactory::create_device(load);
+    auto device = DeviceFactory::create_device(load);
     // it is  a device we support
     if (device != nullptr) {
       device->setParent(this);

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -83,6 +83,12 @@ void DeviceManager::add_new_device(QJsonArray const &payload) {
                     topic.toStdString(), payload.toStdString());
                 m_client.publish(pubmsg);
               });
+
+      connect(device, &QObject::destroyed, this, [this, device] {
+        if (m_devices.remove(device->ieee_address()) > 0) {
+          emit devices_changed();
+        }
+      });
     }
   }
 

--- a/src/include/device_factory.h
+++ b/src/include/device_factory.h
@@ -8,8 +8,10 @@
 
 #include <optional>
 
+#include <QPointer>
+
 namespace DeviceFactory {
-    SmartDevice* create_device(QJsonObject const &data);
+    QPointer<SmartDevice> create_device(QJsonObject const &data);
 
     bool is_light(QJsonObject const &device);
     std::optional<ColorTempRange> getColorTempRange(const QJsonObject& device);

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -17,7 +17,7 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
         explicit DeviceManager(QObject *parent = nullptr);
 
         [[nodiscard]] QList<QPointer<SmartDevice>> devices() const;
-        [[nodiscard]] QPointer<SmartDevice> get_device(QString &id) const;
+        [[nodiscard]] QPointer<SmartDevice> get_device(const QString &id) const;
 
         void handle_message(QString &topic , QJsonObject &payload);
 
@@ -32,7 +32,7 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
     signals:
     
      void devices_changed();
-     void device_discovered(const QPointer<SmartDevice>& device);
+     void device_discovered(SmartDevice *device);
     private:
         QHash<QString, QPointer<SmartDevice>> m_devices;
         mqtt::async_client m_client;   

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -11,7 +11,7 @@
 
 class DeviceManager : public QObject, public virtual mqtt::callback {
     Q_OBJECT
-    Q_PROPERTY(QList<SmartDevice*> devices READ devices NOTIFY devices_changed)
+    Q_PROPERTY(QList<QPointer<SmartDevice>> devices READ devices NOTIFY devices_changed)
 
     public:
         explicit DeviceManager(QObject *parent = nullptr);

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QPointer>
 #include <QObject>
 #include <QList>
 #include <QJsonObject>
@@ -16,7 +17,7 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
         explicit DeviceManager(QObject *parent = nullptr);
 
         [[nodiscard]] QList<SmartDevice*> devices() const;
-        [[nodiscard]] SmartDevice* get_device(QString &id) const;
+        [[nodiscard]] QPointer<SmartDevice> get_device(QString &id) const;
 
         void handle_message(QString &topic , QJsonObject &payload);
 
@@ -31,7 +32,7 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
     signals:
     
      void devices_changed();
-     void device_discovered(SmartDevice *device);
+     void device_discovered(const QPointer<SmartDevice>& device);
     private:
         QHash<QString, SmartDevice*> m_devices;
         mqtt::async_client m_client;   

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -16,7 +16,7 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
     public:
         explicit DeviceManager(QObject *parent = nullptr);
 
-        [[nodiscard]] QList<SmartDevice*> devices() const;
+        [[nodiscard]] QList<QPointer<SmartDevice>> devices() const;
         [[nodiscard]] QPointer<SmartDevice> get_device(QString &id) const;
 
         void handle_message(QString &topic , QJsonObject &payload);
@@ -34,7 +34,7 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
      void devices_changed();
      void device_discovered(const QPointer<SmartDevice>& device);
     private:
-        QHash<QString, SmartDevice*> m_devices;
+        QHash<QString, QPointer<SmartDevice>> m_devices;
         mqtt::async_client m_client;   
 
 };

--- a/src/include/main_window.h
+++ b/src/include/main_window.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <QPointer>
 #include <QtWidgets/QMainWindow>
 #include <QFileSystemWatcher>
 #include <QFileInfo>
@@ -15,16 +16,16 @@ class MainWindow : public QMainWindow {
   Q_OBJECT
 
   public:
-  MainWindow(DeviceManager *manager, QWidget *parent = nullptr);
+  MainWindow(const QPointer<DeviceManager>& manager, QWidget *parent = nullptr);
 
-  void on_device_found(SmartDevice *device);
+  void on_device_found(const QPointer<SmartDevice>& device);
   static void update_style() ;
 
   private:
-  DeviceManager *manager;
-  QWidget *scroll_content;
-  QVBoxLayout *main_layout;
-  QFileSystemWatcher *watcher;
+  QPointer<DeviceManager> manager;
+  QPointer<QWidget> scroll_content;
+  QPointer<QVBoxLayout> main_layout;
+  QPointer<QFileSystemWatcher> watcher;
 
 
 };

--- a/src/include/smart_light.h
+++ b/src/include/smart_light.h
@@ -4,6 +4,7 @@
 #include <QJsonObject>
 #include <QObject>
 #include <QString>
+#include <QPointer>
 
 /*
 Note: my logic assumes mireds, since my lights operate with mireds,
@@ -22,7 +23,7 @@ struct SmartLightParams {
   ColorTempRange color_temp_range;
   int color_temp{};
   int brightness{};
-  QObject *parent = nullptr;
+  QPointer<QObject> parent = nullptr;
 };
 
 class SmartLight : public SmartDevice {

--- a/src/include/smart_light_settings_dialog.h
+++ b/src/include/smart_light_settings_dialog.h
@@ -25,9 +25,10 @@ struct TempSetting {
 class SmartLightSettingsDialog : public BackdropDialog {
 public:
   explicit SmartLightSettingsDialog(const QPointer<SmartLight> &light,
-                                    QWidget *parent = nullptr)
+                                    QWidget *parent)
       : BackdropDialog(parent), light(light) {
-    if (light.isNull()) {
+    if (this->light.isNull()) {
+      QTimer::singleShot(0, this, &QDialog::reject);
       return;
     }
     setup_ui();

--- a/src/include/smart_light_settings_dialog.h
+++ b/src/include/smart_light_settings_dialog.h
@@ -27,6 +27,9 @@ public:
   explicit SmartLightSettingsDialog(const QPointer<SmartLight> &light,
                                     QWidget *parent = nullptr)
       : BackdropDialog(parent), light(light) {
+    if (light.isNull()) {
+      return;
+    }
     setup_ui();
   };
 

--- a/src/include/smart_light_settings_dialog.h
+++ b/src/include/smart_light_settings_dialog.h
@@ -24,7 +24,7 @@ struct TempSetting {
 
 class SmartLightSettingsDialog : public BackdropDialog {
 public:
-  explicit SmartLightSettingsDialog(SmartLight *light,
+  explicit SmartLightSettingsDialog(const QPointer<SmartLight> &light,
                                     QWidget *parent = nullptr)
       : BackdropDialog(parent), light(light) {
     setup_ui();
@@ -32,6 +32,10 @@ public:
 
 protected:
   void setup_ui() override {
+    if (light.isNull()) {
+      return;
+    }
+
     auto *layout = new QVBoxLayout(this); // NOLINT
     layout->addWidget(new QLabel(         // NOLINT
         QString("Light Configuration for %1").arg(light->display_name()),
@@ -74,6 +78,10 @@ protected:
 
     connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
     connect(buttonGroup, &QButtonGroup::idClicked, [this](int choice) {
+      if (light.isNull()) {
+        return;
+      }
+
       const auto selected = static_cast<ColorTempSetting>(choice);
       const ColorTempRange range = light->get_color_temp_range();
 
@@ -101,5 +109,5 @@ protected:
   }
 
 private:
-  SmartLight *light;
+  QPointer<SmartLight> light;
 };

--- a/src/include/smart_light_widget.h
+++ b/src/include/smart_light_widget.h
@@ -1,34 +1,32 @@
 #pragma once
 
 #include "smart_light.h"
-#include <QObject>
-#include <QList>
 #include <QJsonObject>
-#include <QtWidgets/QWidget>
+#include <QList>
+#include <QObject>
+#include <QPointer>
 #include <QtWidgets/QLabel>
-#include <QtWidgets/QSlider>
 #include <QtWidgets/QPushButton>
+#include <QtWidgets/QSlider>
+#include <QtWidgets/QWidget>
 
 class SmartLightWidget : public QWidget {
-    Q_OBJECT
-    public:
-        SmartLightWidget(SmartLight *device, QWidget *parent);
+  Q_OBJECT
+public:
+  SmartLightWidget(const QPointer<SmartLight>& device, const QPointer<QWidget>& parent);
 
-    protected:
-        void resizeEvent(QResizeEvent *event) override;
+protected:
+  void resizeEvent(QResizeEvent *event) override;
 
-    private:
-        SmartLight * m_light_device;
-        QLabel* m_name_label;
-        QSlider *m_brightness_slider;
-        QPushButton *m_toggle_button;
-        QPushButton *btn_reduce_brightness;
-        QPushButton *btn_increase_brightness;
-        QPushButton *btn_settings;
+private:
+  QPointer<SmartLight> m_light_device;
+  QPointer<QLabel> m_name_label;
+  QPointer<QSlider> m_brightness_slider;
+  QPointer<QPushButton> m_toggle_button;
+  QPointer<QPushButton> btn_reduce_brightness;
+  QPointer<QPushButton> btn_increase_brightness;
+  QPointer<QPushButton> btn_settings;
 
-        void setup_connections();
-        void update_slider_label_pos();
-
-
-
+  void setup_connections();
+  void update_slider_label_pos();
 };

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -2,6 +2,7 @@
 
 #include <QString>
 #include <QWidget>
+#include <QPointer>
 
 namespace StringUtils {
 
@@ -10,5 +11,5 @@ QString format_for_display(const QString &string);
 }
 
 namespace WidgetUtils {
-void center_in_window(QWidget *widget);
+void center_in_window(const QPointer<QWidget> &widget);
 }

--- a/src/include/widget_factory.h
+++ b/src/include/widget_factory.h
@@ -2,7 +2,8 @@
 
 #include "smart_device.h"
 #include <QtWidgets/QWidget>
+#include <QPointer>
 
 namespace WidgetFactory {
-    QWidget *create_widget(SmartDevice *device, QWidget *parent);
+    QPointer<QWidget> create_widget(const QPointer<SmartDevice>& device, const QPointer<QWidget>& parent);
 }

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -63,7 +63,7 @@ void MainWindow::on_device_found(const QPointer<SmartDevice> &device) {
   }
 
   auto widget =
-      WidgetFactory::create_widget(device.data(), scroll_content.data());
+      WidgetFactory::create_widget(device, scroll_content);
 
   if (widget == nullptr) {
     return;

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -11,12 +11,16 @@
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QWidget>
 
-MainWindow::MainWindow(DeviceManager *manager, QWidget *parent)
+MainWindow::MainWindow(const QPointer<DeviceManager> &manager, QWidget *parent)
     : QMainWindow(parent), manager(manager) {
+  if (manager.isNull()) {
+    return;
+  }
+
   auto *scroll_area = new QScrollArea(this); // NOLINT
   scroll_area->setWidgetResizable(true);
 
-  scroll_content = new QWidget();                // NOLINT
+  scroll_content = new QWidget(); // NOLINT
   scroll_content->setObjectName("root");
   main_layout = new QVBoxLayout(scroll_content); // NOLINT
 
@@ -25,16 +29,15 @@ MainWindow::MainWindow(DeviceManager *manager, QWidget *parent)
   scroll_area->setWidget(scroll_content);
   this->setCentralWidget(scroll_area);
 
-
   watcher = new QFileSystemWatcher({style_path}, this); // NOLINT
 
-  connect(manager, &DeviceManager::device_discovered, this,
+  connect(manager.data(), &DeviceManager::device_discovered, this,
           &MainWindow::on_device_found);
 
-  connect(watcher, &QFileSystemWatcher::fileChanged, this,
+  connect(watcher.data(), &QFileSystemWatcher::fileChanged, this,
           [this](const QString &path) {
             update_style();
-            if (!watcher->files().contains(path)) {
+            if (watcher && !watcher->files().contains(path)) {
               watcher->addPath(path);
             }
           });
@@ -42,7 +45,8 @@ MainWindow::MainWindow(DeviceManager *manager, QWidget *parent)
 }
 
 void MainWindow::update_style() {
-  std::cout << "[DEBUG] Trying to load style from: " << style_path.toStdString() << "\n";
+  std::cout << "[DEBUG] Trying to load style from: " << style_path.toStdString()
+            << "\n";
   QFile file(style_path);
   if (file.open(QFile::ReadOnly | QFile::Text)) {
     QTextStream stream(&file);
@@ -53,8 +57,13 @@ void MainWindow::update_style() {
   }
 }
 
-void MainWindow::on_device_found(SmartDevice *device) {
-  auto *widget = WidgetFactory::create_widget(device, scroll_content);
+void MainWindow::on_device_found(const QPointer<SmartDevice> &device) {
+  if (device.isNull() || main_layout.isNull() || scroll_content.isNull()) {
+    return;
+  }
+
+  auto widget =
+      WidgetFactory::create_widget(device.data(), scroll_content.data());
 
   if (widget == nullptr) {
     return;

--- a/src/smart_light_widget.cpp
+++ b/src/smart_light_widget.cpp
@@ -19,6 +19,9 @@
 #include <QtWidgets/QWidget>
 
 void SmartLightWidget::update_slider_label_pos() {
+  if (m_brightness_slider.isNull()) {
+    return;
+  }
   auto *label = this->findChild<QLabel *>("label");
   int brightness = this->m_brightness_slider->value();
   label->setText(QString::number(
@@ -37,25 +40,30 @@ void SmartLightWidget::update_slider_label_pos() {
   label->move(x, y);
 }
 
-SmartLightWidget::SmartLightWidget(SmartLight *device, QWidget *parent)
-    : QWidget(parent), m_light_device(device), m_brightness_slider() {
+SmartLightWidget::SmartLightWidget(const QPointer<SmartLight> &device,
+                                   const QPointer<QWidget> &parent)
+    : QWidget(parent.data()), m_light_device(device) {
 
-  auto *layout = new QHBoxLayout(this);                       // NOLINT
-  auto *slider_container = new QHBoxLayout(this);             // NOLINT
-  auto *container = new QVBoxLayout(this);                    // NOLINT
-  auto *label_and_settings_container = new QHBoxLayout(this); // NOLINT
+  if (device.isNull()) {
+    return;
+  }
+
+  auto *layout = new QHBoxLayout(this);                   // NOLINT
+  auto *slider_container = new QHBoxLayout();             // NOLINT
+  auto *container = new QVBoxLayout();                    // NOLINT
+  auto *label_and_settings_container = new QHBoxLayout(); // NOLINT
 
   // label and settings container should be a flex layout
   label_and_settings_container->setProperty("type", "flex");
 
   // button label
-  m_name_label = new QLabel(); // NOLINT
+  m_name_label = new QLabel(this); // NOLINT
   m_name_label->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   m_name_label->setText(device->display_name());
   m_name_label->setAlignment(Qt::AlignLeft);
 
   // settings button
-  btn_settings = new QPushButton(); // NOLINT
+  btn_settings = new QPushButton(this); // NOLINT
   btn_settings->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   QIcon::setThemeName("Adwaita");
   QIcon icon = QIcon::fromTheme("preferences-system-symbolic");
@@ -64,8 +72,8 @@ SmartLightWidget::SmartLightWidget(SmartLight *device, QWidget *parent)
   btn_settings->setProperty("type", "settings_button");
 
   // slider control buttons
-  btn_reduce_brightness = new QPushButton();   // NOLINT
-  btn_increase_brightness = new QPushButton(); // NOLINT
+  btn_reduce_brightness = new QPushButton(this);   // NOLINT
+  btn_increase_brightness = new QPushButton(this); // NOLINT
   btn_increase_brightness->setSizePolicy(QSizePolicy::Preferred,
                                          QSizePolicy::Fixed);
   btn_reduce_brightness->setSizePolicy(QSizePolicy::Preferred,
@@ -75,7 +83,7 @@ SmartLightWidget::SmartLightWidget(SmartLight *device, QWidget *parent)
   btn_reduce_brightness->setText("<");
   btn_increase_brightness->setText(">");
 
-  m_brightness_slider = new QSlider(); // NOLINT
+  m_brightness_slider = new QSlider(this); // NOLINT
   m_brightness_slider->setOrientation(Qt::Orientation::Horizontal);
   m_brightness_slider->setMinimumWidth(100);
   m_brightness_slider->setMinimumHeight(4);
@@ -91,7 +99,7 @@ SmartLightWidget::SmartLightWidget(SmartLight *device, QWidget *parent)
   brightness_label->adjustSize();
   brightness_label->setObjectName("label");
 
-  m_toggle_button = new QPushButton(); // NOLINT
+  m_toggle_button = new QPushButton(this); // NOLINT
   m_toggle_button->setCheckable(true);
   m_toggle_button->setFixedSize(50, 50);
   auto device_state = device->state();
@@ -99,12 +107,12 @@ SmartLightWidget::SmartLightWidget(SmartLight *device, QWidget *parent)
   m_toggle_button->setText(device_state ? "ON" : "OFF");
 
   // connect the shit together
-  slider_container->addWidget(btn_reduce_brightness);
-  slider_container->addWidget(m_brightness_slider, 1);
-  slider_container->addWidget(btn_increase_brightness);
+  slider_container->addWidget(btn_reduce_brightness.data());
+  slider_container->addWidget(m_brightness_slider.data(), 1);
+  slider_container->addWidget(btn_increase_brightness.data());
 
-  label_and_settings_container->addWidget(m_name_label);
-  label_and_settings_container->addWidget(btn_settings);
+  label_and_settings_container->addWidget(m_name_label.data());
+  label_and_settings_container->addWidget(btn_settings.data());
 
   container->addLayout(label_and_settings_container);
   container->addLayout(slider_container, 1);
@@ -112,7 +120,7 @@ SmartLightWidget::SmartLightWidget(SmartLight *device, QWidget *parent)
   container->setSpacing(4);
 
   layout->addLayout(container, 1);
-  layout->addWidget(m_toggle_button);
+  layout->addWidget(m_toggle_button.data());
 
   setup_connections();
 
@@ -125,43 +133,69 @@ void SmartLightWidget::resizeEvent(QResizeEvent *event) {
 }
 
 void SmartLightWidget::setup_connections() {
-  connect(m_brightness_slider, &QSlider::valueChanged, this, [this](int value) {
-    m_light_device->set_brightness(value);
-    this->update_slider_label_pos();
-  });
+  if (m_light_device.isNull()) {
+    return;
+  }
 
-  connect(m_toggle_button, &QPushButton::toggled, this,
-          [this](bool is_checked) { m_light_device->set_state(is_checked); });
-
-  connect(btn_reduce_brightness, &QPushButton::pressed, this, [this]() {
-    const int value = m_brightness_slider->sliderPosition();
-    m_brightness_slider->setValue(value - m_brightness_slider->tickInterval());
-  });
-
-  connect(btn_increase_brightness, &QPushButton::pressed, this, [this]() {
-    const int value = m_brightness_slider->sliderPosition();
-    m_brightness_slider->setValue(value + m_brightness_slider->tickInterval());
-  });
-
-  connect(m_light_device, &SmartLight::brightness_changed, this,
+  connect(m_brightness_slider.data(), &QSlider::valueChanged, this,
           [this](int value) {
-            if (m_brightness_slider->isSliderDown()) {
+            if (m_light_device) {
+              m_light_device->set_brightness(value);
+              this->update_slider_label_pos();
+            }
+          });
+
+  connect(m_toggle_button.data(), &QPushButton::toggled, this,
+          [this](bool is_checked) {
+            if (m_light_device) {
+              m_light_device->set_state(is_checked);
+            }
+          });
+
+  connect(btn_reduce_brightness.data(), &QPushButton::pressed, this, [this]() {
+    if (m_brightness_slider) {
+      const int value = m_brightness_slider->sliderPosition();
+      m_brightness_slider->setValue(value -
+                                    m_brightness_slider->tickInterval());
+    }
+  });
+
+  connect(btn_increase_brightness.data(), &QPushButton::pressed, this,
+          [this]() {
+            if (m_brightness_slider) {
+              const int value = m_brightness_slider->sliderPosition();
+              m_brightness_slider->setValue(
+                  value + m_brightness_slider->tickInterval());
+            }
+          });
+
+  connect(m_light_device.data(), &SmartLight::brightness_changed, this,
+          [this](int value) {
+            if (m_brightness_slider.isNull() ||
+                m_brightness_slider->isSliderDown()) {
               return;
             }
-            const QSignalBlocker blocker(m_brightness_slider);
+            const QSignalBlocker blocker(m_brightness_slider.data());
             m_brightness_slider->setValue(value);
             this->update_slider_label_pos();
           });
 
-  connect(m_light_device, &SmartLight::state_changed, this,
+  connect(m_light_device.data(), &SmartLight::state_changed, this,
           [this](bool is_checked) {
-            const QSignalBlocker blocker(m_toggle_button);
+            if (m_toggle_button.isNull()) {
+              return;
+            }
+            const QSignalBlocker blocker(m_toggle_button.data());
             m_toggle_button->setChecked(is_checked);
             m_toggle_button->setText(is_checked ? "ON" : "OFF");
           });
 
-  connect(btn_settings, &QPushButton::clicked, this, [this]() {
-    auto *dialog = new SmartLightSettingsDialog(m_light_device, this->window()); // NOLINT
+  connect(btn_settings.data(), &QPushButton::clicked, this, [this]() {
+    if (m_light_device.isNull()) {
+      return;
+    }
+    auto *dialog =                                                    // NOLINT
+        new SmartLightSettingsDialog(m_light_device, this->window()); // NOLINT
 
     connect(dialog, &QDialog::finished, this, [this](int result) {
       if (result == QDialog::Accepted) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -22,11 +22,16 @@ void WidgetUtils::center_in_window(const QPointer<QWidget> &widget) {
     return;
   }
 
+  auto *parent = widget->parentWidget();
+  if (parent == nullptr) {
+    return;
+  }
+
   widget->ensurePolished();
   widget->adjustSize();
 
   // Use the content rectangle to avoid title-bar confusion
-  QRect parentArea = widget->parentWidget()->rect();
+  QRect parentArea = parent->rect();
   QRect childRect = widget->rect();
 
   // The math that never fails if dimensions are correct

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 #include <QGuiApplication>
+#include <QPointer>
 #include <QScreen>
 
 QString StringUtils::format_for_display(const QString &string) {
@@ -16,7 +17,11 @@ QString StringUtils::format_for_display(const QString &string) {
   return words_list.join(' ');
 }
 
-void WidgetUtils::center_in_window(QWidget *widget) {
+void WidgetUtils::center_in_window(const QPointer<QWidget> &widget) {
+  if (widget.isNull()) {
+    return;
+  }
+
   widget->ensurePolished();
   widget->adjustSize();
 

--- a/src/widget_factory.cpp
+++ b/src/widget_factory.cpp
@@ -4,17 +4,18 @@
 #include <QJsonObject>
 #include <QString>
 #include <QtWidgets/QWidget>
+#include <QPointer>
 
 #include <algorithm>
 
 namespace WidgetFactory {
-QWidget *create_widget(SmartDevice *device, QWidget *parent) {
-  if (device == nullptr) {
+QPointer<QWidget> create_widget(const QPointer<SmartDevice>& device, const QPointer<QWidget>& parent) {
+  if (device.isNull()) {
     return nullptr;
   }
 
   if (device->device_type() == DeviceType::SmartLight) {
-    auto *light = dynamic_cast<SmartLight *>(device);
+    auto *light = qobject_cast<SmartLight *>(device.data());
     if(light != nullptr) {
         return new SmartLightWidget(light, parent); //NOLINT
     }


### PR DESCRIPTION
Used qpointers as far as posssible in all places


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced raw pointers with Qt pointer wrappers throughout the app; updated public APIs and collections for consistent ownership and nullability semantics.
* **Bug Fixes**
  * Added defensive null checks and early returns, improved parent-aware widget/dialog construction, and hardened signal/slot and device-list handling to stabilize UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->