### PR TITLE
Refactor: Decouple Zigbee logic and introduce Provider architecture

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,10 @@ CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.VariableCase
-    value:           lowerCamelCase
+    value:           lower_case
   - key:             readability-identifier-naming.FunctionCase
-    value:           lowerCamelCase
+    value:           lower_case
+  - key:             readability-identifier-naming.MemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ParameterCase
+    value:           lower_case

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -15,6 +15,15 @@
 
 const std::string mqtt_address{std::string(std::getenv("MQTT_ADDRESS"))};
 
+/**
+ * @brief Constructs a DeviceManager and initializes MQTT integration and device providers.
+ *
+ * Initializes the MQTT client callback, creates and registers the Zigbee provider, and connects
+ * provider signals for device discovery and removal to the manager's handlers. Any exception
+ * thrown during initialization is caught and reported to standard error.
+ *
+ * @param parent QObject ownership parent; ownership of created providers is transferred to this QObject.
+ */
 DeviceManager::DeviceManager(QObject *parent)
     : QObject(parent), m_client(mqtt_address) {
   try {
@@ -36,10 +45,24 @@ QList<QPointer<SmartDevice>> DeviceManager::devices() const {
   return m_devices.values();
 }
 
+/**
+ * Retrieve the managed device matching the given identifier.
+ *
+ * @param id Identifier of the device to look up.
+ * @return QPointer<SmartDevice> Pointer to the matching device, or `nullptr` if no device with that id is managed.
+ */
 QPointer<SmartDevice> DeviceManager::get_device(const QString &id) const {
   return m_devices.value(id, nullptr);
 }
 
+/**
+ * @brief Register a newly discovered device with the manager and notify listeners.
+ *
+ * Adds the provided device to the internal device map keyed by the device's id,
+ * emits devices_changed() and device_discovered() to notify observers, and logs the discovery.
+ *
+ * @param device QPointer to the discovered SmartDevice; if null, the call is ignored.
+ */
 void DeviceManager::on_device_discovered(QPointer<SmartDevice> device) {
   if (!device) return;
   
@@ -51,6 +74,14 @@ void DeviceManager::on_device_discovered(QPointer<SmartDevice> device) {
             << " successfully discovered and added to manager" << "\n";
 }
 
+/**
+ * @brief Remove a device with the given identifier from the manager.
+ *
+ * If a device with the specified id is present, it is removed, the
+ * devices_changed() signal is emitted, and a removal message is logged.
+ *
+ * @param id Identifier of the device to remove; no action is taken if no device matches.
+ */
 void DeviceManager::on_device_removed(const QString &id) {
   if (m_devices.remove(id) > 0) {
     emit devices_changed();
@@ -58,6 +89,15 @@ void DeviceManager::on_device_removed(const QString &id) {
   }
 }
 
+/**
+ * @brief Parse an incoming MQTT message payload as JSON and forward it with the topic to all providers.
+ *
+ * If the payload is a JSON object it is forwarded unchanged; if the payload is a JSON array it is wrapped
+ * into an object under the "devices" key before forwarding. Each non-null provider receives the topic and
+ * resulting JSON object via its handle_message method.
+ *
+ * @param msg Pointer to the received MQTT message.
+ */
 void DeviceManager::message_arrived(mqtt::const_message_ptr msg) {
   QString topic = QString::fromStdString(msg->get_topic());
   QByteArray payload_bytes = QByteArray::fromStdString(msg->get_payload_str());
@@ -81,6 +121,15 @@ void DeviceManager::message_arrived(mqtt::const_message_ptr msg) {
   }
 }
 
+/**
+ * @brief Establishes connection to the configured MQTT broker and initializes providers.
+ *
+ * Connects the MQTT client using a clean session with automatic reconnect, subscribes to all
+ * topics so providers may filter messages themselves, and invokes on_connected() on each
+ * registered provider after a successful connection.
+ *
+ * Any mqtt::exception encountered during connect/subscribe is caught and written to stderr.
+ */
 void DeviceManager::connect_to_broker() {
   try {
     mqtt::connect_options opts = mqtt::connect_options_builder()

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -1,5 +1,5 @@
 #include "device_manager.h"
-#include "device_factory.h"
+#include "zigbee_provider.h"
 #include "smart_device.h"
 
 #include <QJsonArray>
@@ -19,8 +19,16 @@ DeviceManager::DeviceManager(QObject *parent)
     : QObject(parent), m_client(mqtt_address) {
   try {
     m_client.set_callback(*this);
+    
+    // Initialize providers
+    auto* zigbee = new ZigbeeProvider(m_client, this); //NOLINT
+    m_providers.append(zigbee);
+
+    connect(zigbee, &DeviceProvider::device_discovered, this, &DeviceManager::on_device_discovered);
+    connect(zigbee, &DeviceProvider::device_removed, this, &DeviceManager::on_device_removed);
+
   } catch (...) {
-    std::cout << "Could not connect to the bih" << '\n';
+    std::cerr << "Could not connect to the MQTT broker" << '\n';
   }
 }
 
@@ -32,99 +40,46 @@ QPointer<SmartDevice> DeviceManager::get_device(const QString &id) const {
   return m_devices.value(id, nullptr);
 }
 
-void DeviceManager::handle_message(QString &topic, QJsonObject &payload) {
-  std::cout << "Topic: " << topic.toStdString() << '\n';
-
-  if (topic.endsWith("/set")) {
-    return;
-  }
-
-  for (const auto& device : m_devices) {
-    QString device_topic = "zigbee2mqtt/" + device->friendly_name();
-
-    if (topic == device_topic) {
-      device->handle_update(payload);
-      return;
-    }
-  }
-
-  QJsonDocument data{payload};
-
-  std::cout << "Payload: " << data.toJson(QJsonDocument::Indented).toStdString()
-            << '\n';
+void DeviceManager::on_device_discovered(QPointer<SmartDevice> device) {
+  if (!device) return;
+  
+  m_devices[device->id()] = device;
+  emit devices_changed();
+  emit device_discovered(device.get());
+  
+  std::cout << "Device " << device->name().toStdString()
+            << " successfully discovered and added to manager" << "\n";
 }
 
-void DeviceManager::add_new_device(QJsonArray const &payload) {
-  for (const auto data : payload) {
-    auto load = data.toObject();
-    if (load["type"] == "Coordinator") {
-      continue;
-    }
-
-    auto ieee_address = load["ieee_address"].toString();
-
-    if (ieee_address.isEmpty() || this->m_devices.contains(ieee_address)) {
-      continue;
-    }
-
-    auto device = DeviceFactory::create_device(load);
-    // it is  a device we support
-    if (device != nullptr) {
-      device->setParent(this);
-      this->m_devices[ieee_address] = device;
-
-      emit devices_changed();
-      emit device_discovered(device);
-      std::cout << "Device " << device->friendly_name().toStdString()
-                << " successfuully added" << "\n";
-      connect(device, &SmartDevice::send_command, this,
-              [this](const QString &topic, const QString &payload) {
-                mqtt::message_ptr pubmsg = mqtt::make_message(
-                    topic.toStdString(), payload.toStdString());
-                m_client.publish(pubmsg);
-              });
-
-      connect(device, &QObject::destroyed, this, [this, device] {
-        if (m_devices.remove(device->ieee_address()) > 0) {
-          emit devices_changed();
-        }
-      });
-    }
-  }
-
-  for (const auto& device : m_devices) {
-    QString topic = "zigbee2mqtt/" + device->friendly_name() + "/get";
-    QString payload = R"({"state": ""})";
-    mqtt::message_ptr pubmsg =
-        mqtt::make_message(topic.toStdString(), payload.toStdString());
-
-    m_client.publish(pubmsg);
+void DeviceManager::on_device_removed(const QString &id) {
+  if (m_devices.remove(id) > 0) {
+    emit devices_changed();
+    std::cout << "Device " << id.toStdString() << " removed from manager" << "\n";
   }
 }
 
 void DeviceManager::message_arrived(mqtt::const_message_ptr msg) {
-  QString topic{QString::fromStdString(msg->get_topic())};
-  QByteArray payload{QByteArray::fromStdString(msg->get_payload_str())};
-
-  // for the most part I expect that everything will be primarily single JSON
-  // objects for now this is crude but it works
-  // TODO: improve this by making it so that we have a nice little detector for
-  // array vs json values.
-  if (topic.contains("zigbee2mqtt/bridge") && !topic.contains("devices")) {
-    return;
+  QString topic = QString::fromStdString(msg->get_topic());
+  QByteArray payload_bytes = QByteArray::fromStdString(msg->get_payload_str());
+  
+  // We expect JSON payloads for all our devices/providers
+  QJsonDocument doc = QJsonDocument::fromJson(payload_bytes);
+  QJsonObject payload;
+  
+  if (doc.isObject()) {
+    payload = doc.object();
+  } else if (doc.isArray()) {
+    // Some messages (like bridge/devices) might be arrays, wrap them or let providers handle
+    payload["devices"] = doc.array();
   }
 
-  if (topic.contains("bridge/devices")) {
-    QJsonArray payload_json_arr = QJsonDocument::fromJson(payload).array();
-    QMetaObject::invokeMethod(
-        this, [this, payload_json_arr]() { add_new_device(payload_json_arr); });
-    return;
+  // Broadcast to all providers
+  for (auto& provider : m_providers) {
+    if (provider) {
+        provider->handle_message(topic, payload);
+    }
   }
-
-  QJsonObject payload_json{QJsonDocument::fromJson(payload).object()};
-
-  DeviceManager::handle_message(topic, payload_json);
-};
+}
 
 void DeviceManager::connect_to_broker() {
   try {
@@ -134,13 +89,21 @@ void DeviceManager::connect_to_broker() {
                                      .finalize();
 
     m_client.connect(opts)->wait();
-    m_client.subscribe("zigbee2mqtt/#", 1);
-    std::cout << "Requesting device list..." << '\n';
-    m_client.publish("zigbee2mqtt/bridge/devices", "", 1, false)->wait();
+    
+    // Subscribe to all topics so providers can filter what they need
+    m_client.subscribe("#", 1);
+    
+    std::cout << "Connected and Subscribed to all topics" << "\n";
 
-    std::cout << "Connected and Subbed " << "\n";
+    // Notify all providers that we are connected so they can perform discovery/polling
+    for (auto& provider : m_providers) {
+        if (provider) {
+            provider->on_connected();
+        }
+    }
+
   } catch (const mqtt::exception &exc) {
-    std::cerr << exc.get_error_str() << "\n";
+    std::cerr << "MQTT Exception: " << exc.get_error_str() << "\n";
   }
 }
 

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -9,7 +9,7 @@
 #include <mqtt/async_client.h>
 #include <string>
 
-const std::string mqtt_address{std::string(std::getenv("MQTT_ADDRESS"))};
+const std::string mqtt_address{std::string(std::getenv("MQTT_ADDRESS"))}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 /**
  * @brief Constructs a DeviceManager and initializes MQTT integration.
@@ -32,12 +32,16 @@ DeviceManager::DeviceManager(QObject *parent)
  *
  * @param provider Pointer to the DeviceProvider to register.
  */
-void DeviceManager::register_provider(DeviceProvider* provider) {
-    if (!provider) return;
+void DeviceManager::register_provider(DeviceProvider *provider) {
+  if (provider == nullptr) {
+    return;
+  }
 
-    m_providers.append(provider);
-    connect(provider, &DeviceProvider::device_discovered, this, &DeviceManager::on_device_discovered);
-    connect(provider, &DeviceProvider::device_removed, this, &DeviceManager::on_device_removed);
+  m_providers.append(provider);
+  connect(provider, &DeviceProvider::device_discovered, this,
+          &DeviceManager::on_device_discovered);
+  connect(provider, &DeviceProvider::device_removed, this,
+          &DeviceManager::on_device_removed);
 }
 
 QList<QPointer<SmartDevice>> DeviceManager::devices() const {
@@ -48,29 +52,43 @@ QList<QPointer<SmartDevice>> DeviceManager::devices() const {
  * Retrieve the managed device matching the given identifier.
  *
  * @param id Identifier of the device to look up.
- * @return QPointer<SmartDevice> Pointer to the matching device, or `nullptr` if no device with that id is managed.
+ * @return QPointer<SmartDevice> Pointer to the matching device, or `nullptr` if
+ * no device with that id is managed.
  */
 QPointer<SmartDevice> DeviceManager::get_device(const QString &id) const {
   return m_devices.value(id, nullptr);
 }
 
 /**
- * @brief Register a newly discovered device with the manager and notify listeners.
+ * @brief Register a newly discovered device with the manager and notify
+ * listeners.
  *
  * Adds the provided device to the internal device map keyed by the device's id,
- * emits devices_changed() and device_discovered() to notify observers, and logs the discovery.
+ * emits devices_changed(). If the device is new to the manager, it also emits
+ * device_discovered() and logs the discovery.
  *
- * @param device QPointer to the discovered SmartDevice; if null, the call is ignored.
+ * @param device QPointer to the discovered SmartDevice; if null, the call is
+ * ignored.
  */
-void DeviceManager::on_device_discovered(QPointer<SmartDevice> device) {
-  if (!device) return;
-  
-  m_devices[device->id()] = device;
+void DeviceManager::on_device_discovered(const QPointer<SmartDevice> &device) {
+  if (device == nullptr) {
+    return;
+  }
+
+  const QString id = device->id();
+  const bool is_new = !m_devices.contains(id);
+
+  m_devices[id] = device;
   emit devices_changed();
-  emit device_discovered(device.get());
-  
-  std::cout << "Device " << device->name().toStdString()
-            << " successfully discovered and added to manager" << "\n";
+
+  if (is_new) {
+    emit device_discovered(device.get());
+    std::cout << "Device " << device->name().toStdString()
+              << " successfully discovered and added to manager" << "\n";
+  } else {
+    std::cout << "Device " << device->name().toStdString() << " (ID: "
+              << id.toStdString() << ") updated in manager" << "\n";
+  }
 }
 
 /**
@@ -79,62 +97,70 @@ void DeviceManager::on_device_discovered(QPointer<SmartDevice> device) {
  * If a device with the specified id is present, it is removed, the
  * devices_changed() signal is emitted, and a removal message is logged.
  *
- * @param id Identifier of the device to remove; no action is taken if no device matches.
+ * @param id Identifier of the device to remove; no action is taken if no device
+ * matches.
  */
 void DeviceManager::on_device_removed(const QString &id) {
   if (m_devices.remove(id) > 0) {
     emit devices_changed();
-    std::cout << "Device " << id.toStdString() << " removed from manager" << "\n";
+    std::cout << "Device " << id.toStdString() << " removed from manager"
+              << "\n";
   }
 }
 
 /**
- * @brief Forward an incoming MQTT message payload as a raw byte array to all registered providers.
+ * @brief Forward an incoming MQTT message payload as a raw byte array to all
+ * registered providers.
  *
- * Each non-null provider receives the topic and the original payload bytes via its handle_message method.
+ * Each non-null provider receives the topic and the original payload bytes via
+ * its handle_message method.
  *
  * @param msg Pointer to the received MQTT message.
  */
 void DeviceManager::message_arrived(mqtt::const_message_ptr msg) {
-  QString topic = QString::fromStdString(msg->get_topic());
-  QByteArray payload = QByteArray::fromStdString(msg->get_payload_str());
-  
+  const QString topic = QString::fromStdString(msg->get_topic());
+  const QByteArray payload = QByteArray::fromStdString(msg->get_payload_str());
+
   // Broadcast raw bytes to all providers; providers own parsing (JSON, etc.)
-  for (auto& provider : m_providers) {
-    if (provider) {
-        provider->handle_message(topic, payload);
+  for (auto &provider : m_providers) {
+    if (provider != nullptr) {
+      provider->handle_message(topic, payload);
     }
   }
 }
 
 /**
- * @brief Establishes connection to the configured MQTT broker and initializes providers.
+ * @brief Establishes connection to the configured MQTT broker and initializes
+ * providers.
  *
- * Connects the MQTT client using a clean session with automatic reconnect, subscribes to all
- * topics so providers may filter messages themselves, and invokes on_connected() on each
- * registered provider after a successful connection.
+ * Connects the MQTT client using a clean session with automatic reconnect,
+ * subscribes to all topics so providers may filter messages themselves, and
+ * invokes on_connected() on each registered provider after a successful
+ * connection.
  *
- * Any mqtt::exception encountered during connect/subscribe is caught and written to stderr.
+ * Any mqtt::exception encountered during connect/subscribe is caught and
+ * written to stderr.
  */
 void DeviceManager::connect_to_broker() {
   try {
-    mqtt::connect_options opts = mqtt::connect_options_builder()
-                                     .clean_session()
-                                     .automatic_reconnect()
-                                     .finalize();
+    const mqtt::connect_options opts = mqtt::connect_options_builder()
+                                           .clean_session()
+                                           .automatic_reconnect()
+                                           .finalize();
 
     m_client.connect(opts)->wait();
-    
+
     // Subscribe to all topics so providers can filter what they need
     m_client.subscribe("#", 1);
-    
+
     std::cout << "Connected and Subscribed to all topics" << "\n";
 
-    // Notify all providers that we are connected so they can perform discovery/polling
-    for (auto& provider : m_providers) {
-        if (provider) {
-            provider->on_connected();
-        }
+    // Notify all providers that we are connected so they can perform
+    // discovery/polling
+    for (auto &provider : m_providers) {
+      if (provider != nullptr) {
+        provider->on_connected();
+      }
     }
 
   } catch (const mqtt::exception &exc) {
@@ -142,5 +168,5 @@ void DeviceManager::connect_to_broker() {
   }
 }
 
-void DeviceManager::connection_lost(const std::string & /*cause*/) {};
-void DeviceManager::delivery_complete(mqtt::delivery_token_ptr /*token*/){};
+void DeviceManager::connection_lost(const std::string & /*cause*/) {}
+void DeviceManager::delivery_complete(mqtt::delivery_token_ptr /*token*/) {}

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -1,9 +1,6 @@
 #include "device_manager.h"
 #include "smart_device.h"
 
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QList>
 #include <QObject>
 #include <QString>
@@ -92,30 +89,17 @@ void DeviceManager::on_device_removed(const QString &id) {
 }
 
 /**
- * @brief Parse an incoming MQTT message payload as JSON and forward it with the topic to all providers.
+ * @brief Forward an incoming MQTT message payload as a raw byte array to all registered providers.
  *
- * If the payload is a JSON object it is forwarded unchanged; if the payload is a JSON array it is wrapped
- * into an object under the "devices" key before forwarding. Each non-null provider receives the topic and
- * resulting JSON object via its handle_message method.
+ * Each non-null provider receives the topic and the original payload bytes via its handle_message method.
  *
  * @param msg Pointer to the received MQTT message.
  */
 void DeviceManager::message_arrived(mqtt::const_message_ptr msg) {
   QString topic = QString::fromStdString(msg->get_topic());
-  QByteArray payload_bytes = QByteArray::fromStdString(msg->get_payload_str());
+  QByteArray payload = QByteArray::fromStdString(msg->get_payload_str());
   
-  // We expect JSON payloads for all our devices/providers
-  QJsonDocument doc = QJsonDocument::fromJson(payload_bytes);
-  QJsonObject payload;
-  
-  if (doc.isObject()) {
-    payload = doc.object();
-  } else if (doc.isArray()) {
-    // Some messages (like bridge/devices) might be arrays, wrap them or let providers handle
-    payload["devices"] = doc.array();
-  }
-
-  // Broadcast to all providers
+  // Broadcast raw bytes to all providers; providers own parsing (JSON, etc.)
   for (auto& provider : m_providers) {
     if (provider) {
         provider->handle_message(topic, payload);

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -1,5 +1,4 @@
 #include "device_manager.h"
-#include "zigbee_provider.h"
 #include "smart_device.h"
 
 #include <QJsonArray>
@@ -16,29 +15,32 @@
 const std::string mqtt_address{std::string(std::getenv("MQTT_ADDRESS"))};
 
 /**
- * @brief Constructs a DeviceManager and initializes MQTT integration and device providers.
+ * @brief Constructs a DeviceManager and initializes MQTT integration.
  *
- * Initializes the MQTT client callback, creates and registers the Zigbee provider, and connects
- * provider signals for device discovery and removal to the manager's handlers. Any exception
- * thrown during initialization is caught and reported to standard error.
+ * Initializes the MQTT client callback.
  *
- * @param parent QObject ownership parent; ownership of created providers is transferred to this QObject.
+ * @param parent QObject ownership parent.
  */
 DeviceManager::DeviceManager(QObject *parent)
     : QObject(parent), m_client(mqtt_address) {
   try {
     m_client.set_callback(*this);
-    
-    // Initialize providers
-    auto* zigbee = new ZigbeeProvider(m_client, this); //NOLINT
-    m_providers.append(zigbee);
-
-    connect(zigbee, &DeviceProvider::device_discovered, this, &DeviceManager::on_device_discovered);
-    connect(zigbee, &DeviceProvider::device_removed, this, &DeviceManager::on_device_removed);
-
   } catch (...) {
     std::cerr << "Could not connect to the MQTT broker" << '\n';
   }
+}
+
+/**
+ * @brief Register a device provider with the manager.
+ *
+ * @param provider Pointer to the DeviceProvider to register.
+ */
+void DeviceManager::register_provider(DeviceProvider* provider) {
+    if (!provider) return;
+
+    m_providers.append(provider);
+    connect(provider, &DeviceProvider::device_discovered, this, &DeviceManager::on_device_discovered);
+    connect(provider, &DeviceProvider::device_removed, this, &DeviceManager::on_device_removed);
 }
 
 QList<QPointer<SmartDevice>> DeviceManager::devices() const {

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -35,7 +35,7 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
      void device_discovered(SmartDevice *device);
 
     private slots:
-        void on_device_discovered(QPointer<SmartDevice> device);
+        void on_device_discovered(const QPointer<SmartDevice> &device);
         void on_device_removed(const QString &id);
 
     private:

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -9,33 +9,94 @@
 #include "smart_device.h"
 #include "device_provider.h"
 
-
+/**
+ * @brief Manages a collection of smart devices and their providers.
+ * 
+ * DeviceManager acts as a central hub for discovering, tracking, and communicating
+ * with smart devices via various providers. It also handles MQTT connection.
+ */
 class DeviceManager : public QObject, public virtual mqtt::callback {
     Q_OBJECT
     Q_PROPERTY(QList<QPointer<SmartDevice>> devices READ devices NOTIFY devices_changed)
 
     public:
+        /**
+         * @brief Construct a DeviceManager.
+         * @param parent Optional QObject parent.
+         */
         explicit DeviceManager(QObject *parent = nullptr);
 
+        /**
+         * @brief Register a device provider.
+         * @param provider Pointer to the DeviceProvider to register.
+         */
         void register_provider(DeviceProvider* provider);
+
+        /**
+         * @brief Get the internal MQTT client.
+         * @returns Reference to the mqtt::async_client.
+         */
         mqtt::async_client& mqtt_client() { return m_client; }
 
+        /**
+         * @brief Get the list of managed devices.
+         * @returns QList of pointers to managed SmartDevice instances.
+         */
         [[nodiscard]] QList<QPointer<SmartDevice>> devices() const;
+
+        /**
+         * @brief Get a device by its unique identifier.
+         * @param id Unique identifier of the device.
+         * @returns QPointer to the SmartDevice if found, or null otherwise.
+         */
         [[nodiscard]] QPointer<SmartDevice> get_device(const QString &id) const;
 
+        /**
+         * @brief Called when MQTT connection is lost.
+         * @param cause Reason for connection loss.
+         */
         void connection_lost(const std::string &cause) override;
+
+        /**
+         * @brief Called when an MQTT message arrives.
+         * @param msg The received MQTT message.
+         */
         void message_arrived(mqtt::const_message_ptr msg) override;
+
+        /**
+         * @brief Called when MQTT delivery is complete.
+         * @param token Token for the delivered message.
+         */
         void delivery_complete(mqtt::delivery_token_ptr token) override;
 
+        /**
+         * @brief Establish connection to the MQTT broker.
+         */
         void connect_to_broker();
 
     signals:
-    
-     void devices_changed();
-     void device_discovered(SmartDevice *device);
+        /**
+         * @brief Emitted when the list of managed devices changes.
+         */
+        void devices_changed();
+
+        /**
+         * @brief Emitted when a new device is discovered.
+         * @param device Pointer to the newly discovered SmartDevice.
+         */
+        void device_discovered(SmartDevice *device);
 
     private slots:
+        /**
+         * @brief Internal slot to handle device discovery from providers.
+         * @param device Pointer to the discovered device.
+         */
         void on_device_discovered(const QPointer<SmartDevice> &device);
+
+        /**
+         * @brief Internal slot to handle device removal from providers.
+         * @param id Unique identifier of the removed device.
+         */
         void on_device_removed(const QString &id);
 
     private:

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -6,7 +6,8 @@
 #include <QJsonObject>
 #include <mqtt/async_client.h>
 
-#include <smart_device.h>
+#include "smart_device.h"
+#include "device_provider.h"
 
 
 class DeviceManager : public QObject, public virtual mqtt::callback {
@@ -19,13 +20,9 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
         [[nodiscard]] QList<QPointer<SmartDevice>> devices() const;
         [[nodiscard]] QPointer<SmartDevice> get_device(const QString &id) const;
 
-        void handle_message(QString &topic , QJsonObject &payload);
-
         void connection_lost(const std::string &cause) override;
         void message_arrived(mqtt::const_message_ptr msg) override;
         void delivery_complete(mqtt::delivery_token_ptr token) override;
-        void add_new_device(QJsonArray const &payload);        
-
 
         void connect_to_broker();
 
@@ -33,7 +30,13 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
     
      void devices_changed();
      void device_discovered(SmartDevice *device);
+
+    private slots:
+        void on_device_discovered(QPointer<SmartDevice> device);
+        void on_device_removed(const QString &id);
+
     private:
+        QList<QPointer<DeviceProvider>> m_providers;
         QHash<QString, QPointer<SmartDevice>> m_devices;
         mqtt::async_client m_client;   
 

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -17,6 +17,9 @@ class DeviceManager : public QObject, public virtual mqtt::callback {
     public:
         explicit DeviceManager(QObject *parent = nullptr);
 
+        void register_provider(DeviceProvider* provider);
+        mqtt::async_client& mqtt_client() { return m_client; }
+
         [[nodiscard]] QList<QPointer<SmartDevice>> devices() const;
         [[nodiscard]] QPointer<SmartDevice> get_device(const QString &id) const;
 

--- a/src/include/device_provider.h
+++ b/src/include/device_provider.h
@@ -4,6 +4,43 @@
 #include <QObject>
 #include <QString>
 
+/**
+ * Abstract base class that discovers and tracks SmartDevice instances and
+ * exposes lifecycle hooks for connection and message handling.
+ */
+ 
+/**
+ * @brief Emitted when a device is discovered and becomes available.
+ * @param device Pointer to the discovered SmartDevice.
+ */
+ 
+/**
+ * @brief Emitted when a device is removed from tracking.
+ * @param id Identifier of the removed device.
+ */
+
+/**
+ * @brief Construct a DeviceProvider with an optional parent QObject.
+ * @param parent Parent QObject, or nullptr.
+ */
+
+/**
+ * @brief Virtual destructor.
+ */
+
+/**
+ * @brief Handle an incoming message associated with a topic.
+ * @param topic Topic or routing key for the message.
+ * @param payload JSON payload of the message.
+ */
+
+/**
+ * @brief Poll all known or discoverable devices to refresh state or discover new ones.
+ */
+
+/**
+ * @brief Called when a connection has been established and the provider can begin communication.
+ */
 class DeviceProvider: public QObject {
     Q_OBJECT
     signals:

--- a/src/include/device_provider.h
+++ b/src/include/device_provider.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QByteArray>
 
 /**
  * Abstract base class that discovers and tracks SmartDevice instances and
@@ -31,7 +32,7 @@
 /**
  * @brief Handle an incoming message associated with a topic.
  * @param topic Topic or routing key for the message.
- * @param payload JSON payload of the message.
+ * @param payload Raw byte array payload of the message.
  */
 
 /**
@@ -53,7 +54,7 @@ class DeviceProvider: public QObject {
 
         Q_DISABLE_COPY_MOVE(DeviceProvider)
 
-        virtual void handle_message(const QString &topic, const QJsonObject &payload) = 0;
+        virtual void handle_message(const QString &topic, const QByteArray &payload) = 0;
         virtual void poll_all_devices() = 0;
         virtual void on_connected() = 0;
     

--- a/src/include/device_provider.h
+++ b/src/include/device_provider.h
@@ -4,6 +4,8 @@
 #include <QObject>
 #include <QString>
 #include <QByteArray>
+#include <QPointer>
+#include <QMap>
 
 /**
  * Abstract base class that discovers and tracks SmartDevice instances and

--- a/src/include/device_provider.h
+++ b/src/include/device_provider.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "smart_device.h"
+
+#include <QObject>
+#include <QString>
+
+class DeviceProvider: public QObject {
+    Q_OBJECT
+    signals:
+        void device_discovered(QPointer<SmartDevice> device);
+        void device_removed(QString id);
+    
+    public: 
+        explicit DeviceProvider(QObject *parent = nullptr): QObject(parent) {}
+        virtual ~DeviceProvider() = default;
+
+        Q_DISABLE_COPY_MOVE(DeviceProvider)
+
+        virtual void handle_message(const QString &topic, const QJsonObject &payload) = 0;
+        virtual void poll_all_devices() = 0;
+        virtual void on_connected() = 0;
+    
+    protected:
+        QMap<QString, QPointer<SmartDevice>> m_devices;
+};

--- a/src/include/device_provider.h
+++ b/src/include/device_provider.h
@@ -8,58 +8,61 @@
 #include <QMap>
 
 /**
- * Abstract base class that discovers and tracks SmartDevice instances and
+ * @brief Abstract base class that discovers and tracks SmartDevice instances and
  * exposes lifecycle hooks for connection and message handling.
- */
- 
-/**
- * @brief Emitted when a device is discovered and becomes available.
- * @param device Pointer to the discovered SmartDevice.
- */
- 
-/**
- * @brief Emitted when a device is removed from tracking.
- * @param id Identifier of the removed device.
- */
-
-/**
- * @brief Construct a DeviceProvider with an optional parent QObject.
- * @param parent Parent QObject, or nullptr.
- */
-
-/**
- * @brief Virtual destructor.
- */
-
-/**
- * @brief Handle an incoming message associated with a topic.
- * @param topic Topic or routing key for the message.
- * @param payload Raw byte array payload of the message.
- */
-
-/**
- * @brief Poll all known or discoverable devices to refresh state or discover new ones.
- */
-
-/**
- * @brief Called when a connection has been established and the provider can begin communication.
  */
 class DeviceProvider: public QObject {
     Q_OBJECT
     signals:
+        /**
+         * @brief Emitted when a device is discovered and becomes available.
+         * @param device Pointer to the discovered SmartDevice.
+         */
         void device_discovered(QPointer<SmartDevice> device);
+
+        /**
+         * @brief Emitted when a device is removed from tracking.
+         * @param id Identifier of the removed device.
+         */
         void device_removed(QString id);
     
     public: 
+        /**
+         * @brief Construct a DeviceProvider with an optional parent QObject.
+         * @param parent Parent QObject, or nullptr.
+         */
         explicit DeviceProvider(QObject *parent = nullptr): QObject(parent) {}
+
+        /**
+         * @brief Virtual destructor.
+         */
         virtual ~DeviceProvider() = default;
 
+        /**
+         * @brief Disable copy and move constructors.
+         */
         Q_DISABLE_COPY_MOVE(DeviceProvider)
 
+        /**
+         * @brief Handle an incoming message associated with a topic.
+         * @param topic Topic or routing key for the message.
+         * @param payload Raw byte array payload of the message.
+         */
         virtual void handle_message(const QString &topic, const QByteArray &payload) = 0;
+
+        /**
+         * @brief Poll all known or discoverable devices to refresh state or discover new ones.
+         */
         virtual void poll_all_devices() = 0;
+
+        /**
+         * @brief Called when a connection has been established and the provider can begin communication.
+         */
         virtual void on_connected() = 0;
     
     protected:
+        /**
+         * @brief Map of managed devices keyed by their unique identifier.
+         */
         QMap<QString, QPointer<SmartDevice>> m_devices;
 };

--- a/src/include/mqtt_capability.h
+++ b/src/include/mqtt_capability.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QString>
+#include <concepts>
+#include <utility>
+#include <mqtt/async_client.h>
+
+template <typename T>
+concept MqttProvider = requires(T p) {
+  { p.mqtt_client() } -> std::same_as<mqtt::async_client*>;
+  { p.mqtt_topic_prefix() } -> std::same_as<QString>;
+};
+
+class MqttMixin {
+public:
+  MqttMixin(mqtt::async_client &client, QString prefix)
+      : client(client), topic_prefix(std::move(prefix)) {}
+
+  mqtt::async_client* mqtt_client() { return &client; }
+
+  [[nodiscard]] QString mqtt_topic_prefix() const { return topic_prefix; }
+
+  protected:
+    mqtt::async_client &client;
+    QString topic_prefix;
+};

--- a/src/include/mqtt_capability.h
+++ b/src/include/mqtt_capability.h
@@ -5,6 +5,9 @@
 #include <utility>
 #include <mqtt/async_client.h>
 
+/**
+ * @brief Concept for a provider that uses MQTT.
+ */
 template <typename T>
 concept MqttProvider = requires(T p) {
   { p.mqtt_client() } -> std::same_as<mqtt::async_client*>;
@@ -12,32 +15,31 @@ concept MqttProvider = requires(T p) {
 };
 
 /**
+ * @brief Mixin that provides MQTT client and topic prefix capabilities.
+ * 
  * MqttMixin provides a reusable mixin that stores a non-owning reference to an MQTT
  * asynchronous client and a topic prefix, exposing accessors for derived classes.
  */
-
-/**
- * Construct an MqttMixin with a reference to an existing MQTT client and a topic prefix.
- * @param client Reference to an existing mqtt::async_client that the mixin will reference (non-owning).
- * @param prefix Topic prefix to store for MQTT topics; ownership is transferred into the mixin.
- */
-
-/**
- * Provide access to the stored MQTT asynchronous client.
- * @returns Pointer to the referenced mqtt::async_client.
- */
-
-/**
- * Access the stored MQTT topic prefix.
- * @returns The QString topic prefix.
- */
 class MqttMixin {
 public:
+  /**
+   * @brief Construct an MqttMixin.
+   * @param client Reference to an existing mqtt::async_client (non-owning).
+   * @param prefix Topic prefix to store for MQTT topics.
+   */
   MqttMixin(mqtt::async_client &client, QString prefix)
       : client(client), topic_prefix(std::move(prefix)) {}
 
+  /**
+   * @brief Provide access to the stored MQTT asynchronous client.
+   * @returns Pointer to the referenced mqtt::async_client.
+   */
   mqtt::async_client* mqtt_client() { return &client; }
 
+  /**
+   * @brief Access the stored MQTT topic prefix.
+   * @returns The QString topic prefix.
+   */
   [[nodiscard]] QString mqtt_topic_prefix() const { return topic_prefix; }
 
   protected:

--- a/src/include/mqtt_capability.h
+++ b/src/include/mqtt_capability.h
@@ -11,6 +11,26 @@ concept MqttProvider = requires(T p) {
   { p.mqtt_topic_prefix() } -> std::same_as<QString>;
 };
 
+/**
+ * MqttMixin provides a reusable mixin that stores a non-owning reference to an MQTT
+ * asynchronous client and a topic prefix, exposing accessors for derived classes.
+ */
+
+/**
+ * Construct an MqttMixin with a reference to an existing MQTT client and a topic prefix.
+ * @param client Reference to an existing mqtt::async_client that the mixin will reference (non-owning).
+ * @param prefix Topic prefix to store for MQTT topics; ownership is transferred into the mixin.
+ */
+
+/**
+ * Provide access to the stored MQTT asynchronous client.
+ * @returns Pointer to the referenced mqtt::async_client.
+ */
+
+/**
+ * Access the stored MQTT topic prefix.
+ * @returns The QString topic prefix.
+ */
 class MqttMixin {
 public:
   MqttMixin(mqtt::async_client &client, QString prefix)

--- a/src/include/smart_device.h
+++ b/src/include/smart_device.h
@@ -4,6 +4,46 @@
 #include <QObject>
 #include <QString>
 
+/**
+ * Construct a SmartDevice with identifiers, display properties, and device type.
+ * @param id Device unique identifier (e.g., IEEE address or internal id).
+ * @param name Human-friendly device name.
+ * @param model Device model identifier.
+ * @param type DeviceType enum value describing the device category.
+ * @param parent Optional QObject parent.
+ */
+/**
+ * Get the device name.
+ * @returns The human-friendly name of the device.
+ */
+/**
+ * Get the device model identifier.
+ * @returns The model identifier string.
+ */
+/**
+ * Get the device unique identifier.
+ * @returns The device id string.
+ */
+/**
+ * Get the device on/off state.
+ * @returns `true` if the device is on, `false` otherwise.
+ */
+/**
+ * Get the device type.
+ * @returns The DeviceType value for this device.
+ */
+/**
+ * Get the device display name.
+ * @returns The display name used for UI presentation.
+ */
+/**
+ * Set the device on/off state.
+ * @param state `true` to mark the device as on, `false` to mark it as off.
+ */
+/**
+ * Handle an incoming JSON payload to update device state or produce commands.
+ * @param payload JSON object containing update information or command data relevant to the device.
+ */
 enum class DeviceType { SmartLight };
 
 class SmartDevice : public QObject {

--- a/src/include/smart_device.h
+++ b/src/include/smart_device.h
@@ -1,28 +1,24 @@
 #pragma once
 
+#include <QJsonObject>
 #include <QObject>
 #include <QString>
-#include <QJsonObject>
 
-
-enum class DeviceType {
-  SmartLight
-};
+enum class DeviceType { SmartLight };
 
 class SmartDevice : public QObject {
   Q_OBJECT
-  Q_PROPERTY(
-      QString friendly_name READ friendly_name NOTIFY friendly_name_changed)
-  Q_PROPERTY(QString ieee_address READ ieee_address CONSTANT)
-  Q_PROPERTY(QString model_id READ model_id CONSTANT)
+  Q_PROPERTY(QString id READ id CONSTANT)
+  Q_PROPERTY(QString name READ name NOTIFY name_changed)
+  Q_PROPERTY(QString model READ model CONSTANT)
+  Q_PROPERTY(QString display_name READ display_name CONSTANT)
   Q_PROPERTY(bool state READ state WRITE set_state NOTIFY state_changed)
-
 public:
   SmartDevice( QString id,  QString name, QString model, DeviceType type, QObject *parent = nullptr);
 
-  [[nodiscard]] QString friendly_name() const;
-  [[nodiscard]] QString model_id() const;
-  [[nodiscard]] QString ieee_address() const;
+  [[nodiscard]] QString name() const;
+  [[nodiscard]] QString model() const;
+  [[nodiscard]] QString id() const;
   [[nodiscard]] bool state() const;
   [[nodiscard]] DeviceType device_type() const;
   [[nodiscard]] QString display_name() const;
@@ -42,16 +38,16 @@ public:
 signals:
 
   void state_changed(bool state);
-  void friendly_name_changed();
-  void send_command(QString topic, QString payload);
-
+  void name_changed();
+  
+  void request_command(const QJsonObject &command);
 protected:
   void update_state(bool state);
 
 private:
-  QString m_friendly_name;
-  QString m_model_id;
-  QString m_ieee_address;
+  QString m_name;
+  QString m_model;
+  QString m_id;
   QString m_display_name;
   DeviceType type;
   bool m_state;

--- a/src/include/smart_device.h
+++ b/src/include/smart_device.h
@@ -5,47 +5,13 @@
 #include <QString>
 
 /**
- * Construct a SmartDevice with identifiers, display properties, and device type.
- * @param id Device unique identifier (e.g., IEEE address or internal id).
- * @param name Human-friendly device name.
- * @param model Device model identifier.
- * @param type DeviceType enum value describing the device category.
- * @param parent Optional QObject parent.
- */
-/**
- * Get the device name.
- * @returns The human-friendly name of the device.
- */
-/**
- * Get the device model identifier.
- * @returns The model identifier string.
- */
-/**
- * Get the device unique identifier.
- * @returns The device id string.
- */
-/**
- * Get the device on/off state.
- * @returns `true` if the device is on, `false` otherwise.
- */
-/**
- * Get the device type.
- * @returns The DeviceType value for this device.
- */
-/**
- * Get the device display name.
- * @returns The display name used for UI presentation.
- */
-/**
- * Set the device on/off state.
- * @param state `true` to mark the device as on, `false` to mark it as off.
- */
-/**
- * Handle an incoming JSON payload to update device state or produce commands.
- * @param payload JSON object containing update information or command data relevant to the device.
+ * @brief Enum representing the type of smart device.
  */
 enum class DeviceType { SmartLight };
 
+/**
+ * @brief Base class for all smart devices in the system.
+ */
 class SmartDevice : public QObject {
   Q_OBJECT
   Q_PROPERTY(QString id READ id CONSTANT)
@@ -54,34 +20,98 @@ class SmartDevice : public QObject {
   Q_PROPERTY(QString display_name READ display_name CONSTANT)
   Q_PROPERTY(bool state READ state WRITE set_state NOTIFY state_changed)
 public:
+  /**
+   * @brief Construct a SmartDevice with identifiers, display properties, and device type.
+   * @param id Device unique identifier (e.g., IEEE address or internal id).
+   * @param name Human-friendly device name.
+   * @param model Device model identifier.
+   * @param type DeviceType enum value describing the device category.
+   * @param parent Optional QObject parent.
+   */
   SmartDevice( QString id,  QString name, QString model, DeviceType type, QObject *parent = nullptr);
 
+  /**
+   * @brief Get the device name.
+   * @returns The human-friendly name of the device.
+   */
   [[nodiscard]] QString name() const;
+
+  /**
+   * @brief Get the device model identifier.
+   * @returns The model identifier string.
+   */
   [[nodiscard]] QString model() const;
+
+  /**
+   * @brief Get the device unique identifier.
+   * @returns The device id string.
+   */
   [[nodiscard]] QString id() const;
+
+  /**
+   * @brief Get the device on/off state.
+   * @returns `true` if the device is on, `false` otherwise.
+   */
   [[nodiscard]] bool state() const;
+
+  /**
+   * @brief Get the device type.
+   * @returns The DeviceType value for this device.
+   */
   [[nodiscard]] DeviceType device_type() const;
+
+  /**
+   * @brief Get the device display name.
+   * @returns The display name used for UI presentation.
+   */
   [[nodiscard]] QString display_name() const;
 
+  /**
+   * @brief Set the device on/off state.
+   * @param state `true` to mark the device as on, `false` to mark it as off.
+   */
   void set_state(bool state);
 
+  /**
+   * @brief Handle an incoming JSON payload to update device state or produce commands.
+   * @param payload JSON object containing update information or command data relevant to the device.
+   */
   virtual void handle_update(QJsonObject const  &payload) = 0;
 
-  //For memory we specify the virtual destructure to ensure that derived classes are cleaned
-  // when using polymorphism 
+  /**
+   * @brief Virtual destructor to ensure that derived classes are cleaned when using polymorphism.
+   */
   virtual ~SmartDevice() = default;
 
-  //but since we defined the destructor we need to also explicitly create the copy/move constructors
-  // this would adhere to the rule of 5 since now the compiler will NOT create them by default
+  /**
+   * @brief Disable copy and move constructors to adhere to the rule of 5.
+   */
   Q_DISABLE_COPY_MOVE(SmartDevice)
 
 signals:
 
+  /**
+   * @brief Emitted when the device state changes.
+   * @param state New state of the device.
+   */
   void state_changed(bool state);
+
+  /**
+   * @brief Emitted when the device name changes.
+   */
   void name_changed();
   
+  /**
+   * @brief Emitted when a command is requested for the device.
+   * @param command JSON object containing the command data.
+   */
   void request_command(const QJsonObject &command);
+
 protected:
+  /**
+   * @brief Internal method to update the device state without emitting a command.
+   * @param state New state of the device.
+   */
   void update_state(bool state);
 
 private:

--- a/src/include/smart_device.h
+++ b/src/include/smart_device.h
@@ -89,6 +89,6 @@ private:
   QString m_model;
   QString m_id;
   QString m_display_name;
-  DeviceType type;
+  DeviceType m_type;
   bool m_state;
 };

--- a/src/include/smart_light.h
+++ b/src/include/smart_light.h
@@ -6,16 +6,20 @@
 #include <QString>
 #include <QPointer>
 
-/*
-Note: my logic assumes mireds, since my lights operate with mireds,
-i am too lazy to handle kelvin lol so thats a future me problem
-*/
+/**
+ * @brief Represents a range of color temperatures.
+ * 
+ * Note: Assumes values are in mireds.
+ */
 struct ColorTempRange {
   int min{};
   int max{};
   int neutral{};
 };
 
+/**
+ * @brief Parameters for constructing a SmartLight.
+ */
 struct SmartLightParams {
   QString id;
   QString name;
@@ -26,6 +30,9 @@ struct SmartLightParams {
   QPointer<QObject> parent = nullptr;
 };
 
+/**
+ * @brief Base class for smart lights.
+ */
 class SmartLight : public SmartDevice {
   Q_OBJECT
   Q_PROPERTY(int brightness READ brightness WRITE set_brightness NOTIFY
@@ -34,26 +41,74 @@ class SmartLight : public SmartDevice {
                  color_temp_changed)
 
 public:
+  /**
+   * @brief Construct a SmartLight.
+   * @param params Construction parameters.
+   */
   explicit SmartLight(SmartLightParams params);
 
+  /**
+   * @brief Get the current brightness.
+   * @returns Brightness level (0-254).
+   */
   [[nodiscard]] int brightness() const;
+
+  /**
+   * @brief Get the current color temperature.
+   * @returns Color temperature in mireds.
+   */
   [[nodiscard]] int color_temp() const;
+
+  /**
+   * @brief Get the supported color temperature range.
+   * @returns ColorTempRange for the device.
+   */
   [[nodiscard]] ColorTempRange get_color_temp_range() const;
 
+  /**
+   * @brief Set the brightness level.
+   * @param brightness Level to set (0-254).
+   */
   virtual void set_brightness(int brightness) = 0;
+
+  /**
+   * @brief Set the color temperature.
+   * @param color_temp Temperature in mireds.
+   */
   virtual void set_color_temp(int color_temp) = 0;
 
+  /**
+   * @brief Handle an incoming JSON payload.
+   */
   void handle_update(QJsonObject const &payload) override = 0;
 
   static constexpr int min_brightness = 0;
   static constexpr int max_brightness = 254;
 
 signals:
+  /**
+   * @brief Emitted when the brightness changes.
+   * @param brightness New brightness level.
+   */
   void brightness_changed(int brightness);
+
+  /**
+   * @brief Emitted when the color temperature changes.
+   * @param color_temp New color temperature level.
+   */
   void color_temp_changed(int color_temp);
 
 protected:
+  /**
+   * @brief Internal method to update the brightness state.
+   * @param brightness New brightness level.
+   */
   void update_brightness(int brightness);
+
+  /**
+   * @brief Internal method to update the color temperature state.
+   * @param color_temp New color temperature level.
+   */
   void update_color_temp(int color_temp);
 
   int m_brightness;

--- a/src/include/smart_light.h
+++ b/src/include/smart_light.h
@@ -58,5 +58,5 @@ protected:
 
   int m_brightness;
   int m_color_temp;
-  ColorTempRange color_temp_range;
+  ColorTempRange m_color_temp_range;
 };

--- a/src/include/zigbee_light.h
+++ b/src/include/zigbee_light.h
@@ -1,14 +1,36 @@
 #pragma once
 #include "smart_light.h"
 
+/**
+ * @brief Represents a Zigbee smart light.
+ * 
+ * Implements Zigbee-specific state updates and command creation.
+ */
 class ZigbeeLight: public SmartLight {
     Q_OBJECT
 
     public:
+        /**
+         * @brief Construct a ZigbeeLight.
+         * @param params Construction parameters.
+         */
         explicit ZigbeeLight(SmartLightParams params);
 
+        /**
+         * @brief Handle an incoming JSON payload from Zigbee2MQTT.
+         * @param payload JSON object containing the device state.
+         */
         void handle_update(QJsonObject const &payload) override;
 
+        /**
+         * @brief Set the brightness level and emit a Zigbee-specific command.
+         * @param brightness Level to set (0-254).
+         */
         void set_brightness(int brightness) override;
+
+        /**
+         * @brief Set the color temperature and emit a Zigbee-specific command.
+         * @param color_temp Temperature in mireds.
+         */
         void set_color_temp(int color_temp) override;
 };

--- a/src/include/zigbee_provider.h
+++ b/src/include/zigbee_provider.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "device_provider.h"
+#include "mqtt_capability.h"
+#include <QMap>
+
+class ZigbeeProvider : public DeviceProvider, public MqttMixin {
+    Q_OBJECT
+    public:
+        explicit ZigbeeProvider(mqtt::async_client &client, QObject *parent = nullptr);
+
+    void handle_message(const QString &topic, const QJsonObject &payload) override;
+    void poll_all_devices() override;
+    void on_connected() override;
+    
+    private:
+        void process_discovery(const QJsonArray &devices);
+        void route_update(const QString &friendly_name, const QJsonObject &payload);
+    
+    protected:
+        QMap<QString, QString> m_name_to_id;
+};

--- a/src/include/zigbee_provider.h
+++ b/src/include/zigbee_provider.h
@@ -9,7 +9,7 @@ class ZigbeeProvider : public DeviceProvider, public MqttMixin {
     public:
         explicit ZigbeeProvider(mqtt::async_client &client, QObject *parent = nullptr);
 
-    void handle_message(const QString &topic, const QJsonObject &payload) override;
+    void handle_message(const QString &topic, const QByteArray &payload) override;
     void poll_all_devices() override;
     void on_connected() override;
     

--- a/src/include/zigbee_provider.h
+++ b/src/include/zigbee_provider.h
@@ -2,23 +2,30 @@
 
 #include "device_provider.h"
 #include "mqtt_capability.h"
-#include <QMap>
-#include <QJsonObject>
 #include <QJsonArray>
+#include <QJsonObject>
+#include <QMap>
+#include <QSet>
 
 class ZigbeeProvider : public DeviceProvider, public MqttMixin {
-    Q_OBJECT
-    public:
-        explicit ZigbeeProvider(mqtt::async_client &client, QObject *parent = nullptr);
+  Q_OBJECT
+public:
+  explicit ZigbeeProvider(mqtt::async_client &client, QObject *parent = nullptr);
 
-    void handle_message(const QString &topic, const QByteArray &payload) override;
-    void poll_all_devices() override;
-    void on_connected() override;
-    
-    private:
-        void process_discovery(const QJsonArray &devices);
-        void route_update(const QString &friendly_name, const QJsonObject &payload);
-    
-    protected:
-        QMap<QString, QString> m_name_to_id;
+  void handle_message(const QString &topic, const QByteArray &payload) override;
+  void poll_all_devices() override;
+  void on_connected() override;
+
+private:
+  void process_discovery(const QJsonArray &devices);
+  void route_update(const QString &friendly_name, const QJsonObject &payload);
+
+  // Helper methods for discovery
+  [[nodiscard]] static QSet<QString> extract_snapshot_ids(const QJsonArray &devices) ;
+  void register_new_devices(const QJsonArray &devices);
+  void setup_new_device(const QPointer<SmartDevice> &device);
+  void reconcile_missing_devices(const QSet<QString> &snapshot_ids);
+
+protected:
+  QMap<QString, QString> m_name_to_id;
 };

--- a/src/include/zigbee_provider.h
+++ b/src/include/zigbee_provider.h
@@ -7,25 +7,83 @@
 #include <QMap>
 #include <QSet>
 
+/**
+ * @brief Device provider for Zigbee devices via Zigbee2MQTT.
+ * 
+ * Handles discovery and state management for Zigbee devices by communicating
+ * with a Zigbee2MQTT bridge over MQTT.
+ */
 class ZigbeeProvider : public DeviceProvider, public MqttMixin {
   Q_OBJECT
 public:
+  /**
+   * @brief Construct a ZigbeeProvider.
+   * @param client Reference to the MQTT client.
+   * @param parent Optional QObject parent.
+   */
   explicit ZigbeeProvider(mqtt::async_client &client, QObject *parent = nullptr);
 
+  /**
+   * @brief Handle an incoming MQTT message.
+   * @param topic Topic of the message.
+   * @param payload Raw payload bytes.
+   */
   void handle_message(const QString &topic, const QByteArray &payload) override;
+
+  /**
+   * @brief Poll all known devices for their current state.
+   */
   void poll_all_devices() override;
+
+  /**
+   * @brief Called when the MQTT client connects to the broker.
+   * 
+   * Triggers device discovery by requesting the bridge's device list.
+   */
   void on_connected() override;
 
 private:
+  /**
+   * @brief Process a device discovery payload from the bridge.
+   * @param devices JSON array of device descriptors.
+   */
   void process_discovery(const QJsonArray &devices);
+
+  /**
+   * @brief Route a state update to a specific device.
+   * @param friendly_name Friendly name of the device.
+   * @param payload JSON object containing the update.
+   */
   void route_update(const QString &friendly_name, const QJsonObject &payload);
 
-  // Helper methods for discovery
+  /**
+   * @brief Extract IEEE addresses from a discovery payload.
+   * @param devices JSON array of device descriptors.
+   * @returns QSet of unique IEEE addresses.
+   */
   [[nodiscard]] static QSet<QString> extract_snapshot_ids(const QJsonArray &devices) ;
+
+  /**
+   * @brief Register any new devices found in the discovery payload.
+   * @param devices JSON array of device descriptors.
+   */
   void register_new_devices(const QJsonArray &devices);
+
+  /**
+   * @brief Perform initial setup for a newly discovered device.
+   * @param device Pointer to the SmartDevice.
+   */
   void setup_new_device(const QPointer<SmartDevice> &device);
+
+  /**
+   * @brief Remove devices that are no longer present in the bridge's snapshot.
+   * @param snapshot_ids Set of IEEE addresses currently present in the bridge.
+   */
   void reconcile_missing_devices(const QSet<QString> &snapshot_ids);
 
 protected:
+  /**
+   * @brief Mapping from device friendly names to their unique IEEE addresses.
+   */
   QMap<QString, QString> m_name_to_id;
 };

--- a/src/include/zigbee_provider.h
+++ b/src/include/zigbee_provider.h
@@ -3,6 +3,8 @@
 #include "device_provider.h"
 #include "mqtt_capability.h"
 #include <QMap>
+#include <QJsonObject>
+#include <QJsonArray>
 
 class ZigbeeProvider : public DeviceProvider, public MqttMixin {
     Q_OBJECT

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "device_manager.h"
 #include "main_window.h"
+#include "zigbee_provider.h"
 
 #include <iostream>
 
@@ -11,6 +12,9 @@
 int main(int argc, char *argv[]) {
   QApplication app(argc, argv);
   DeviceManager manager;
+  
+  auto* zigbee = new ZigbeeProvider(manager.mqtt_client(), &manager);
+  manager.register_provider(zigbee);
 
   QFile file(style_path);
   if(file.open(QFile::ReadOnly | QFile::Text)) {

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -12,7 +12,8 @@
 #include <QtWidgets/QWidget>
 
 MainWindow::MainWindow(const QPointer<DeviceManager> &manager, QWidget *parent)
-    : QMainWindow(parent), manager(manager) {
+    : QMainWindow(parent), manager(manager), scroll_content(nullptr),
+      main_layout(nullptr), watcher(nullptr) {
   if (manager.isNull()) {
     return;
   }
@@ -20,7 +21,7 @@ MainWindow::MainWindow(const QPointer<DeviceManager> &manager, QWidget *parent)
   auto *scroll_area = new QScrollArea(this); // NOLINT
   scroll_area->setWidgetResizable(true);
 
-  scroll_content = new QWidget(); // NOLINT
+  scroll_content = new QWidget();                // NOLINT
   scroll_content->setObjectName("root");
   main_layout = new QVBoxLayout(scroll_content); // NOLINT
 
@@ -57,13 +58,14 @@ void MainWindow::update_style() {
   }
 }
 
-void MainWindow::on_device_found(const QPointer<SmartDevice> &device) {
+void MainWindow::on_device_found(
+    const QPointer<SmartDevice>
+        &device) { // NOLINT(readability-convert-member-functions-to-static)
   if (device.isNull() || main_layout.isNull() || scroll_content.isNull()) {
     return;
   }
 
-  auto widget =
-      WidgetFactory::create_widget(device, scroll_content);
+  auto widget = WidgetFactory::create_widget(device, scroll_content);
 
   if (widget == nullptr) {
     return;

--- a/src/smart_device.cpp
+++ b/src/smart_device.cpp
@@ -8,16 +8,16 @@
 
 SmartDevice::SmartDevice(QString id, QString name, QString model,
                          DeviceType type, QObject *parent)
-    : QObject(parent), m_friendly_name(std::move(name)),
-      m_model_id(std::move(model)), m_ieee_address(std::move(id)), type(type),
+    : QObject(parent), m_name(std::move(name)),
+      m_model(std::move(model)), m_id(std::move(id)), type(type),
       m_state(false) {
-  m_display_name = StringUtils::format_for_display(m_friendly_name);
+  m_display_name = StringUtils::format_for_display(m_name);
 }
 
-QString SmartDevice::friendly_name() const { return this->m_friendly_name; };
+QString SmartDevice::name() const { return this->m_name; }
 
-QString SmartDevice::model_id() const { return this->m_model_id; }
-QString SmartDevice::ieee_address() const { return this->m_ieee_address; }
+QString SmartDevice::model() const { return this->m_model; }
+QString SmartDevice::id() const { return this->m_id; }
 DeviceType SmartDevice::device_type() const { return this->type; }
 QString SmartDevice::display_name() const { return this->m_display_name; }
 
@@ -38,9 +38,8 @@ void SmartDevice::set_state(bool state) {
   }
 
   update_state(state);
-  QString topic = "zigbee2mqtt/" + friendly_name() + "/set";
-
-  QString state_str = state ? "ON" : "OFF";
-  QString payload = QString(R"({"state": "%1"})").arg(state_str);
-  emit send_command(topic, payload);
+  
+  QJsonObject command;
+  command["state"] = state ? "ON" : "OFF";
+  emit request_command(command);
 }

--- a/src/smart_device.cpp
+++ b/src/smart_device.cpp
@@ -17,13 +17,12 @@
  * @param type DeviceType enum value describing the device category.
  * @param parent Optional QObject parent for ownership. 
  */
-SmartDevice::SmartDevice(QString id, QString name, QString model,
+SmartDevice::SmartDevice(QString id, QString name, QString model, // NOLINT(bugprone-easily-swappable-parameters)
                          DeviceType type, QObject *parent)
-    : QObject(parent), m_name(std::move(name)),
-      m_model(std::move(model)), m_id(std::move(id)), type(type),
-      m_state(false) {
-  m_display_name = StringUtils::format_for_display(m_name);
-}
+    : QObject(parent), m_name(std::move(name)), m_model(std::move(model)),
+      m_id(std::move(id)),
+      m_display_name(StringUtils::format_for_display(m_name)), m_type(type),
+      m_state(false) {}
 
 /**
  * @brief Retrieve the device's configured name.
@@ -49,7 +48,7 @@ QString SmartDevice::id() const { return this->m_id; }
  *
  * @return DeviceType The enum value representing this device's type.
  */
-DeviceType SmartDevice::device_type() const { return this->type; }
+DeviceType SmartDevice::device_type() const { return this->m_type; }
 /**
  * @brief Human-friendly display name for the device.
  *

--- a/src/smart_device.cpp
+++ b/src/smart_device.cpp
@@ -75,9 +75,9 @@ void SmartDevice::update_state(bool state) {
  *
  * Updates the device state only if the provided state differs from the current state,
  * and emits the request_command signal with a QJsonObject containing the key
- * "state" mapped to "ON" or "OFF".
+ * "state" mapped to a boolean value.
  *
- * @param state `true` to set the device to "ON", `false` to set it to "OFF".
+ * @param state `true` to set the device to on, `false` to set it to off.
  */
 void SmartDevice::set_state(bool state) {
   if (state == m_state) {
@@ -87,6 +87,6 @@ void SmartDevice::set_state(bool state) {
   update_state(state);
   
   QJsonObject command;
-  command["state"] = state ? "ON" : "OFF";
+  command["state"] = state;
   emit request_command(command);
 }

--- a/src/smart_device.cpp
+++ b/src/smart_device.cpp
@@ -6,6 +6,17 @@
 #include <QString>
 #include <utility>
 
+/**
+ * @brief Construct a SmartDevice with identifying and descriptive properties.
+ *
+ * Initializes a SmartDevice's id, name, model, device type, and QObject parent; computes the device's display name from the provided name and initializes its state to false.
+ *
+ * @param id Unique device identifier (e.g., IEEE address).
+ * @param name Human-readable device name.
+ * @param model Device model identifier.
+ * @param type DeviceType enum value describing the device category.
+ * @param parent Optional QObject parent for ownership. 
+ */
 SmartDevice::SmartDevice(QString id, QString name, QString model,
                          DeviceType type, QObject *parent)
     : QObject(parent), m_name(std::move(name)),
@@ -14,11 +25,38 @@ SmartDevice::SmartDevice(QString id, QString name, QString model,
   m_display_name = StringUtils::format_for_display(m_name);
 }
 
+/**
+ * @brief Retrieve the device's configured name.
+ *
+ * @return QString The device name.
+ */
 QString SmartDevice::name() const { return this->m_name; }
 
+/**
+ * @brief Get the device model identifier.
+ *
+ * @return QString The device model identifier.
+ */
 QString SmartDevice::model() const { return this->m_model; }
+/**
+ * @brief Retrieves the device's unique identifier (IEEE address).
+ *
+ * @return QString The device identifier.
+ */
 QString SmartDevice::id() const { return this->m_id; }
+/**
+ * @brief Retrieve the device's type.
+ *
+ * @return DeviceType The enum value representing this device's type.
+ */
 DeviceType SmartDevice::device_type() const { return this->type; }
+/**
+ * @brief Human-friendly display name for the device.
+ *
+ * The display name is computed from the device name during construction (formatted for display).
+ *
+ * @return QString The formatted display name used for presentation.
+ */
 QString SmartDevice::display_name() const { return this->m_display_name; }
 
 bool SmartDevice::state() const { return this->m_state; }
@@ -32,6 +70,15 @@ void SmartDevice::update_state(bool state) {
   emit this->state_changed(m_state);
 }
 
+/**
+ * @brief Set the device's on/off state and request a command when the state changes.
+ *
+ * Updates the device state only if the provided state differs from the current state,
+ * and emits the request_command signal with a QJsonObject containing the key
+ * "state" mapped to "ON" or "OFF".
+ *
+ * @param state `true` to set the device to "ON", `false` to set it to "OFF".
+ */
 void SmartDevice::set_state(bool state) {
   if (state == m_state) {
     return;

--- a/src/smart_light.cpp
+++ b/src/smart_light.cpp
@@ -10,11 +10,11 @@ SmartLight::SmartLight(SmartLightParams params)
                   std::move(params.model), DeviceType::SmartLight,
                   params.parent),
       m_brightness(params.brightness), m_color_temp(params.color_temp),
-      color_temp_range(params.color_temp_range) {}
+      m_color_temp_range(params.color_temp_range) {}
 
 int SmartLight::brightness() const { return this->m_brightness; }
 int SmartLight::color_temp() const { return this->m_color_temp; }
-ColorTempRange SmartLight::get_color_temp_range() const { return this->color_temp_range; }
+ColorTempRange SmartLight::get_color_temp_range() const { return this->m_color_temp_range; }
 
 void SmartLight::update_brightness(int brightness) {
   if (brightness == m_brightness) {

--- a/src/smart_light_widget.cpp
+++ b/src/smart_light_widget.cpp
@@ -40,9 +40,14 @@ void SmartLightWidget::update_slider_label_pos() {
   label->move(x, y);
 }
 
-SmartLightWidget::SmartLightWidget(const QPointer<SmartLight> &device,
-                                   const QPointer<QWidget> &parent)
-    : QWidget(parent.data()), m_light_device(device) {
+SmartLightWidget::SmartLightWidget(
+    const QPointer<SmartLight> &device,
+    const QPointer<QWidget>
+        &parent) // NOLINT(bugprone-easily-swappable-parameters)
+    : QWidget(parent.data()), m_light_device(device), m_name_label(nullptr),
+      m_brightness_slider(nullptr), m_toggle_button(nullptr),
+      btn_reduce_brightness(nullptr), btn_increase_brightness(nullptr),
+      btn_settings(nullptr) {
 
   if (device.isNull()) {
     return;
@@ -102,7 +107,7 @@ SmartLightWidget::SmartLightWidget(const QPointer<SmartLight> &device,
   m_toggle_button = new QPushButton(this); // NOLINT
   m_toggle_button->setCheckable(true);
   m_toggle_button->setFixedSize(50, 50);
-  auto device_state = device->state();
+  const auto device_state = device->state();
   m_toggle_button->setChecked(device_state);
   m_toggle_button->setText(device_state ? "ON" : "OFF");
 
@@ -127,12 +132,13 @@ SmartLightWidget::SmartLightWidget(const QPointer<SmartLight> &device,
   this->setAttribute(Qt::WA_StyledBackground, true);
 }
 
-void SmartLightWidget::resizeEvent(QResizeEvent *event) {
+void SmartLightWidget::resizeEvent(
+    QResizeEvent *event) { // NOLINT(readability-identifier-naming)
   QWidget::resizeEvent(event);
   this->update_slider_label_pos();
 }
 
-void SmartLightWidget::setup_connections() {
+void SmartLightWidget::setup_connections() { // NOLINT(readability-convert-member-functions-to-static)
   if (m_light_device.isNull()) {
     return;
   }
@@ -197,7 +203,7 @@ void SmartLightWidget::setup_connections() {
     auto *dialog =                                                    // NOLINT
         new SmartLightSettingsDialog(m_light_device, this->window()); // NOLINT
 
-    connect(dialog, &QDialog::finished, this, [this](int result) {
+    connect(dialog, &QDialog::finished, this, [](int result) {
       if (result == QDialog::Accepted) {
         // Update logic goes here
       }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -31,12 +31,12 @@ void WidgetUtils::center_in_window(const QPointer<QWidget> &widget) {
   widget->adjustSize();
 
   // Use the content rectangle to avoid title-bar confusion
-  QRect parentArea = parent->rect();
-  QRect childRect = widget->rect();
+  const QRect parent_area = parent->rect();
+  const QRect child_rect = widget->rect();
 
   // The math that never fails if dimensions are correct
-  int x = (parentArea.width() - childRect.width()) / 2;
-  int y = (parentArea.height() - childRect.height()) / 2;
+  const int x = (parent_area.width() - child_rect.width()) / 2;
+  const int y = (parent_area.height() - child_rect.height()) / 2;
 
   widget->move(x, y);
 }

--- a/src/zigbee_light.cpp
+++ b/src/zigbee_light.cpp
@@ -5,6 +5,14 @@
 ZigbeeLight::ZigbeeLight(SmartLightParams params)
     : SmartLight(std::move(params)) {}
 
+/**
+ * @brief Set the light's brightness and emit an update command when it changes.
+ *
+ * Updates the internal brightness value if different from the current value and emits
+ * a QJsonObject command with a "brightness" field via the request_command signal.
+ *
+ * @param brightness Desired brightness level to apply.
+ */
 void ZigbeeLight::set_brightness(const int brightness) {
   if (brightness == this->m_brightness) {
     return;
@@ -17,6 +25,15 @@ void ZigbeeLight::set_brightness(const int brightness) {
   emit request_command(command);
 }
 
+/**
+ * @brief Update the light's color temperature and request the change.
+ *
+ * If the provided value differs from the current color temperature, updates the internal
+ * color temperature and emits request_command with a QJsonObject containing a
+ * "color_temp" field set to the provided value.
+ *
+ * @param color_temp New color temperature value.
+ */
 void ZigbeeLight::set_color_temp(const int color_temp) {
   if (color_temp == this->m_color_temp) {
     return;
@@ -29,6 +46,18 @@ void ZigbeeLight::set_color_temp(const int color_temp) {
   emit request_command(command);
 }
 
+/**
+ * @brief Apply an incoming update payload to the light's internal state.
+ *
+ * Parses the provided JSON payload and updates the light's on/off state,
+ * brightness, and color temperature when those fields are present.
+ *
+ * The `state` field may be either a string (expects "ON" for on) or a boolean.
+ * The `brightness` and `color_temp` fields are interpreted as integers; absent
+ * or missing values are ignored.
+ *
+ * @param payload JSON object that may contain keys "state", "brightness", and "color_temp".
+ */
 void ZigbeeLight::handle_update(QJsonObject const &payload) {
   auto state = payload["state"];
   auto brightness = payload["brightness"].toInt(-1);

--- a/src/zigbee_light.cpp
+++ b/src/zigbee_light.cpp
@@ -12,10 +12,9 @@ void ZigbeeLight::set_brightness(const int brightness) {
 
   update_brightness(brightness);
 
-  QString topic = "zigbee2mqtt/" + friendly_name() + "/set";
-  QString payload = QString("{\"brightness\": %1}").arg(m_brightness);
-
-  emit send_command(topic, payload);
+  QJsonObject command;
+  command["brightness"] = brightness;
+  emit request_command(command);
 }
 
 void ZigbeeLight::set_color_temp(const int color_temp) {
@@ -25,10 +24,9 @@ void ZigbeeLight::set_color_temp(const int color_temp) {
 
   update_color_temp(color_temp);
 
-  QString topic = "zigbee2mqtt/" + friendly_name() + "/set";
-  QString payload = QString("{\"color_temp\": %1}").arg(m_color_temp);
-
-  emit send_command(topic, payload);
+  QJsonObject command;
+  command["color_temp"] = color_temp;
+  emit request_command(command);
 }
 
 void ZigbeeLight::handle_update(QJsonObject const &payload) {

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -5,25 +5,27 @@
 #include <QObject>
 
 /**
-     * @brief Create a Zigbee provider bound to an MQTT client and the "zigbee2mqtt/" topic prefix.
-     *
-     * Initializes a provider that publishes and subscribes using the given MQTT client under the
-     * "zigbee2mqtt/" topic namespace.
-     *
-     * @param client MQTT asynchronous client used for publishing and subscribing.
-     * @param parent Optional QObject parent for ownership and lifetime management.
-     */
-    ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
+ * @brief Create a Zigbee provider bound to an MQTT client and the
+ * "zigbee2mqtt/" topic prefix.
+ *
+ * Initializes a provider that publishes and subscribes using the given MQTT
+ * client under the "zigbee2mqtt/" topic namespace.
+ *
+ * @param client MQTT asynchronous client used for publishing and subscribing.
+ * @param parent Optional QObject parent for ownership and lifetime management.
+ */
+ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
     : DeviceProvider(parent), MqttMixin(client, "zigbee2mqtt/") {}
 
 /**
- * @brief Process an incoming MQTT message and route it to the appropriate handler.
+ * @brief Process an incoming MQTT message and route it to the appropriate
+ * handler.
  *
- * Inspects the MQTT topic and either ignores irrelevant topics, handles a bridge discovery
- * message, or forwards a device update to its route handler.
+ * Inspects the MQTT topic and either ignores irrelevant topics, handles a
+ * bridge discovery message, or forwards a device update to its route handler.
  *
- * @param topic Full MQTT topic string for the incoming message; must start with the provider's
- *              MQTT topic prefix to be processed.
+ * @param topic Full MQTT topic string for the incoming message; must start with
+ * the provider's MQTT topic prefix to be processed.
  * @param payload Raw byte array payload of the MQTT message.
  */
 void ZigbeeProvider::handle_message(const QString &topic,
@@ -40,14 +42,14 @@ void ZigbeeProvider::handle_message(const QString &topic,
   if (topic == mqtt_topic_prefix() + "bridge/devices") {
     QJsonArray devices;
     if (doc.isArray()) {
-        devices = doc.array();
+      devices = doc.array();
     } else if (doc.isObject()) {
-        devices = doc.object()["devices"].toArray();
+      devices = doc.object()["devices"].toArray();
     }
-    
+
     if (!devices.isEmpty()) {
-        process_discovery(devices);
-        poll_all_devices();
+      process_discovery(devices);
+      poll_all_devices();
     }
     return;
   }
@@ -57,22 +59,23 @@ void ZigbeeProvider::handle_message(const QString &topic,
   if (name.contains("bridge")) {
     return;
   }
-  
+
   if (doc.isObject()) {
     route_update(name, doc.object());
   }
 }
 
 /**
- * @brief Processes a discovery payload from Zigbee2MQTT and registers new devices.
+ * @brief Processes a discovery payload from Zigbee2MQTT and registers new
+ * devices.
  *
- * Iterates the provided array of device descriptors, ignoring coordinator entries
- * and entries without an `ieee_address` or already-registered devices. For each
- * newly created device the provider stores mappings (id → device, name → id),
- * emits `device_discovered`, connects the device's request_command signal so
- * that outgoing commands are published to the MQTT topic "<prefix><device_name>/set",
- * and attaches a cleanup handler that removes mappings and emits `device_removed`
- * when the device is destroyed.
+ * Iterates the provided array of device descriptors, ignoring coordinator
+ * entries and entries without an `ieee_address` or already-registered devices.
+ * For each newly created device the provider stores mappings (id → device, name
+ * → id), emits `device_discovered`, connects the device's request_command
+ * signal so that outgoing commands are published to the MQTT topic
+ * "<prefix><device_name>/set", and attaches a cleanup handler that removes
+ * mappings and emits `device_removed` when the device is destroyed.
  *
  * @param devices Array of device objects as received from the Zigbee2MQTT
  *                bridge (each object is expected to contain an
@@ -98,7 +101,10 @@ void ZigbeeProvider::process_discovery(const QJsonArray &devices) {
       m_name_to_id[device->name()] = device->id();
 
       connect(device, &SmartDevice::request_command, this,
-              [this, device](const QJsonObject &command) {
+              [this, device](QJsonObject command) {
+                if (command.contains("state") && command["state"].isBool()) {
+                  command["state"] = command["state"].toBool() ? "ON" : "OFF";
+                }
                 QString topic = mqtt_topic_prefix() + device->name() + "/set";
                 QJsonDocument doc(command);
                 mqtt::message_ptr pubmsg = mqtt::make_message(
@@ -122,11 +128,14 @@ void ZigbeeProvider::process_discovery(const QJsonArray &devices) {
 }
 
 /**
- * @brief Routes an incoming payload to the device identified by its friendly name.
+ * @brief Routes an incoming payload to the device identified by its friendly
+ * name.
  *
- * If the friendly name maps to a known device and that device exists, forwards the payload to the device's update handler; otherwise does nothing.
+ * If the friendly name maps to a known device and that device exists, forwards
+ * the payload to the device's update handler; otherwise does nothing.
  *
- * @param friendly_name Friendly name of the target device (as derived from the MQTT topic).
+ * @param friendly_name Friendly name of the target device (as derived from the
+ * MQTT topic).
  * @param payload JSON payload to deliver to the device.
  */
 void ZigbeeProvider::route_update(const QString &friendly_name,
@@ -143,9 +152,11 @@ void ZigbeeProvider::route_update(const QString &friendly_name,
 }
 
 /**
- * @brief Requests Zigbee2MQTT to enumerate devices by publishing to the bridge devices topic.
+ * @brief Requests Zigbee2MQTT to enumerate devices by publishing to the bridge
+ * devices topic.
  *
- * Publishes an empty payload to "<prefix>bridge/devices" via the provider's MQTT client to trigger device discovery.
+ * Publishes an empty payload to "<prefix>bridge/devices" via the provider's
+ * MQTT client to trigger device discovery.
  */
 void ZigbeeProvider::on_connected() {
   QString topic = mqtt_topic_prefix() + "bridge/devices";
@@ -155,13 +166,13 @@ void ZigbeeProvider::on_connected() {
 /**
  * @brief Requests state updates from every known Zigbee device.
  *
- * Iterates stored devices and publishes a {"state": ""} get payload to each device's
- * MQTT "<prefix><device_name>/get" topic; null entries are skipped.
+ * Iterates stored devices and publishes a {"state": ""} get payload to each
+ * device's MQTT "<prefix><device_name>/get" topic; null entries are skipped.
  */
 void ZigbeeProvider::poll_all_devices() {
   for (const auto &device : m_devices) {
-    if(device == nullptr) {
-        continue;
+    if (device == nullptr) {
+      continue;
     }
     QString topic = mqtt_topic_prefix() + device->name() + "/get";
     QString payload = R"({"state": ""})";

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -1,0 +1,105 @@
+
+#include "zigbee_provider.h"
+#include "device_factory.h"
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QObject>
+
+ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
+    : DeviceProvider(parent), MqttMixin(client, "zigbee2mqtt/") {}
+
+void ZigbeeProvider::handle_message(const QString &topic,
+                                    const QJsonObject &payload) {
+  if (!topic.startsWith(mqtt_topic_prefix()) || topic.endsWith("/set")) {
+    return;
+  }
+
+  if (topic == mqtt_topic_prefix() + "bridge/devices") {
+    QJsonArray devices = payload["devices"].toArray();
+    process_discovery(devices);
+    poll_all_devices();
+    return;
+  }
+
+  QString name = topic.mid(mqtt_topic_prefix().length());
+
+  if (name.contains("bridge")) {
+    return;
+  }
+  route_update(name, payload);
+}
+
+void ZigbeeProvider::process_discovery(const QJsonArray &devices) {
+  for (const auto data : devices) {
+    auto load = data.toObject();
+    if (load["type"] == "Coordinator") {
+      continue;
+    }
+
+    auto id = load["ieee_address"].toString();
+
+    if (id.isEmpty() || this->m_devices.contains(id)) {
+      continue;
+    }
+
+    auto device = DeviceFactory::create_device(load);
+
+    if (device != nullptr) {
+      m_devices[id] = device;
+      m_name_to_id[device->name()] = device->id();
+
+      connect(device, &SmartDevice::request_command, this,
+              [this, device](const QJsonObject &command) {
+                QString topic = mqtt_topic_prefix() + device->name() + "/set";
+                QJsonDocument doc(command);
+                mqtt::message_ptr pubmsg = mqtt::make_message(
+                    topic.toStdString(),
+                    doc.toJson(QJsonDocument::Compact).toStdString());
+                mqtt_client()->publish(pubmsg);
+              });
+
+      emit device_discovered(device);
+
+      QString id = device->id();
+      QString name = device->name();
+
+      connect(device, &QObject::destroyed, this, [this, id, name] {
+        m_devices.remove(id);
+        m_name_to_id.remove(name);
+        emit device_removed(id);
+      });
+    }
+  }
+}
+
+void ZigbeeProvider::route_update(const QString &friendly_name,
+                                  const QJsonObject &payload) {
+  if (!m_name_to_id.contains(friendly_name)) {
+    return;
+  }
+  auto id = m_name_to_id.value(friendly_name);
+  auto device = m_devices.value(id);
+
+  if (device != nullptr) {
+    device->handle_update(payload);
+  };
+}
+
+void ZigbeeProvider::on_connected() {
+  QString topic = mqtt_topic_prefix() + "bridge/devices";
+  mqtt_client()->publish(mqtt::make_message(topic.toStdString(), "", 1, false));
+}
+
+void ZigbeeProvider::poll_all_devices() {
+  for (const auto &device : m_devices) {
+    if(device == nullptr) {
+        continue;
+    }
+    QString topic = mqtt_topic_prefix() + device->name() + "/get";
+    QString payload = R"({"state": ""})";
+    mqtt::message_ptr pubmsg =
+        mqtt::make_message(topic.toStdString(), payload.toStdString());
+
+    mqtt_client()->publish(pubmsg);
+  }
+}

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -30,7 +30,14 @@ ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
  */
 void ZigbeeProvider::handle_message(const QString &topic,
                                     const QByteArray &payload) {
-  if (!topic.startsWith(mqtt_topic_prefix()) || topic.endsWith("/set")) {
+  if (!topic.startsWith(mqtt_topic_prefix())) {
+    return;
+  }
+
+  QString rel_topic = topic.mid(mqtt_topic_prefix().length());
+
+  // Ignore outgoing commands (topics ending in "/set" for a device)
+  if (rel_topic.endsWith("/set")) {
     return;
   }
 
@@ -39,32 +46,31 @@ void ZigbeeProvider::handle_message(const QString &topic,
     return;
   }
 
-  if (topic == mqtt_topic_prefix() + "bridge/devices") {
+  // Precise bridge namespace check
+  if (rel_topic == "bridge/devices") {
     QJsonArray devices;
     if (doc.isArray()) {
-      devices = doc.array();
+        devices = doc.array();
     } else if (doc.isObject()) {
-      devices = doc.object()["devices"].toArray();
+        devices = doc.object()["devices"].toArray();
     }
 
     if (!devices.isEmpty()) {
-      process_discovery(devices);
-      poll_all_devices();
+        process_discovery(devices);
+        poll_all_devices();
     }
     return;
   }
 
-  QString name = topic.mid(mqtt_topic_prefix().length());
-
-  if (name.contains("bridge")) {
+  if (rel_topic == "bridge" || rel_topic.startsWith("bridge/")) {
     return;
   }
 
+  // If it's not a command and not in the bridge namespace, it's a device update
   if (doc.isObject()) {
-    route_update(name, doc.object());
+    route_update(rel_topic, doc.object());
   }
 }
-
 /**
  * @brief Processes a discovery payload from Zigbee2MQTT and registers new
  * devices.

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -1,13 +1,31 @@
-
 #include "zigbee_provider.h"
 #include "device_factory.h"
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QObject>
 
-ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
+/**
+     * @brief Create a Zigbee provider bound to an MQTT client and the "zigbee2mqtt/" topic prefix.
+     *
+     * Initializes a provider that publishes and subscribes using the given MQTT client under the
+     * "zigbee2mqtt/" topic namespace.
+     *
+     * @param client MQTT asynchronous client used for publishing and subscribing.
+     * @param parent Optional QObject parent for ownership and lifetime management.
+     */
+    ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
     : DeviceProvider(parent), MqttMixin(client, "zigbee2mqtt/") {}
 
+/**
+ * @brief Process an incoming MQTT message and route it to the appropriate handler.
+ *
+ * Inspects the MQTT topic and either ignores irrelevant topics, handles a bridge discovery
+ * message, or forwards a device update to its route handler.
+ *
+ * @param topic Full MQTT topic string for the incoming message; must start with the provider's
+ *              MQTT topic prefix to be processed.
+ * @param payload JSON payload of the MQTT message.
+ */
 void ZigbeeProvider::handle_message(const QString &topic,
                                     const QJsonObject &payload) {
   if (!topic.startsWith(mqtt_topic_prefix()) || topic.endsWith("/set")) {
@@ -29,6 +47,21 @@ void ZigbeeProvider::handle_message(const QString &topic,
   route_update(name, payload);
 }
 
+/**
+ * @brief Processes a discovery payload from Zigbee2MQTT and registers new devices.
+ *
+ * Iterates the provided array of device descriptors, ignoring coordinator entries
+ * and entries without an `ieee_address` or already-registered devices. For each
+ * newly created device the provider stores mappings (id → device, name → id),
+ * emits `device_discovered`, connects the device's request_command signal so
+ * that outgoing commands are published to the MQTT topic "<prefix><device_name>/set",
+ * and attaches a cleanup handler that removes mappings and emits `device_removed`
+ * when the device is destroyed.
+ *
+ * @param devices Array of device objects as received from the Zigbee2MQTT
+ *                bridge (each object is expected to contain an
+ *                `ieee_address` and a `name`/`type` field).
+ */
 void ZigbeeProvider::process_discovery(const QJsonArray &devices) {
   for (const auto data : devices) {
     auto load = data.toObject();
@@ -72,6 +105,14 @@ void ZigbeeProvider::process_discovery(const QJsonArray &devices) {
   }
 }
 
+/**
+ * @brief Routes an incoming payload to the device identified by its friendly name.
+ *
+ * If the friendly name maps to a known device and that device exists, forwards the payload to the device's update handler; otherwise does nothing.
+ *
+ * @param friendly_name Friendly name of the target device (as derived from the MQTT topic).
+ * @param payload JSON payload to deliver to the device.
+ */
 void ZigbeeProvider::route_update(const QString &friendly_name,
                                   const QJsonObject &payload) {
   if (!m_name_to_id.contains(friendly_name)) {
@@ -85,11 +126,22 @@ void ZigbeeProvider::route_update(const QString &friendly_name,
   };
 }
 
+/**
+ * @brief Requests Zigbee2MQTT to enumerate devices by publishing to the bridge devices topic.
+ *
+ * Publishes an empty payload to "<prefix>bridge/devices" via the provider's MQTT client to trigger device discovery.
+ */
 void ZigbeeProvider::on_connected() {
   QString topic = mqtt_topic_prefix() + "bridge/devices";
   mqtt_client()->publish(mqtt::make_message(topic.toStdString(), "", 1, false));
 }
 
+/**
+ * @brief Requests state updates from every known Zigbee device.
+ *
+ * Iterates stored devices and publishes a {"state": ""} get payload to each device's
+ * MQTT "<prefix><device_name>/get" topic; null entries are skipped.
+ */
 void ZigbeeProvider::poll_all_devices() {
   for (const auto &device : m_devices) {
     if(device == nullptr) {

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -24,18 +24,31 @@
  *
  * @param topic Full MQTT topic string for the incoming message; must start with the provider's
  *              MQTT topic prefix to be processed.
- * @param payload JSON payload of the MQTT message.
+ * @param payload Raw byte array payload of the MQTT message.
  */
 void ZigbeeProvider::handle_message(const QString &topic,
-                                    const QJsonObject &payload) {
+                                    const QByteArray &payload) {
   if (!topic.startsWith(mqtt_topic_prefix()) || topic.endsWith("/set")) {
     return;
   }
 
+  QJsonDocument doc = QJsonDocument::fromJson(payload);
+  if (doc.isNull()) {
+    return;
+  }
+
   if (topic == mqtt_topic_prefix() + "bridge/devices") {
-    QJsonArray devices = payload["devices"].toArray();
-    process_discovery(devices);
-    poll_all_devices();
+    QJsonArray devices;
+    if (doc.isArray()) {
+        devices = doc.array();
+    } else if (doc.isObject()) {
+        devices = doc.object()["devices"].toArray();
+    }
+    
+    if (!devices.isEmpty()) {
+        process_discovery(devices);
+        poll_all_devices();
+    }
     return;
   }
 
@@ -44,7 +57,10 @@ void ZigbeeProvider::handle_message(const QString &topic,
   if (name.contains("bridge")) {
     return;
   }
-  route_update(name, payload);
+  
+  if (doc.isObject()) {
+    route_update(name, doc.object());
+  }
 }
 
 /**

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -3,16 +3,11 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QObject>
+#include <QSet>
 
 /**
  * @brief Create a Zigbee provider bound to an MQTT client and the
  * "zigbee2mqtt/" topic prefix.
- *
- * Initializes a provider that publishes and subscribes using the given MQTT
- * client under the "zigbee2mqtt/" topic namespace.
- *
- * @param client MQTT asynchronous client used for publishing and subscribing.
- * @param parent Optional QObject parent for ownership and lifetime management.
  */
 ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
     : DeviceProvider(parent), MqttMixin(client, "zigbee2mqtt/") {}
@@ -20,44 +15,36 @@ ZigbeeProvider::ZigbeeProvider(mqtt::async_client &client, QObject *parent)
 /**
  * @brief Process an incoming MQTT message and route it to the appropriate
  * handler.
- *
- * Inspects the MQTT topic and either ignores irrelevant topics, handles a
- * bridge discovery message, or forwards a device update to its route handler.
- *
- * @param topic Full MQTT topic string for the incoming message; must start with
- * the provider's MQTT topic prefix to be processed.
- * @param payload Raw byte array payload of the MQTT message.
  */
-void ZigbeeProvider::handle_message(const QString &topic,
-                                    const QByteArray &payload) {
+void ZigbeeProvider::handle_message(
+    const QString &topic, // NOLINT(bugprone-easily-swappable-parameters)
+    const QByteArray &payload) {
   if (!topic.startsWith(mqtt_topic_prefix())) {
     return;
   }
 
-  QString rel_topic = topic.mid(mqtt_topic_prefix().length());
+  const QString rel_topic = topic.mid(mqtt_topic_prefix().length());
 
-  // Ignore outgoing commands (topics ending in "/set" for a device)
   if (rel_topic.endsWith("/set")) {
     return;
   }
 
-  QJsonDocument doc = QJsonDocument::fromJson(payload);
+  const QJsonDocument doc = QJsonDocument::fromJson(payload);
   if (doc.isNull()) {
     return;
   }
 
-  // Precise bridge namespace check
   if (rel_topic == "bridge/devices") {
     QJsonArray devices;
     if (doc.isArray()) {
-        devices = doc.array();
+      devices = doc.array();
     } else if (doc.isObject()) {
-        devices = doc.object()["devices"].toArray();
+      devices = doc.object().value("devices").toArray();
     }
 
     if (!devices.isEmpty()) {
-        process_discovery(devices);
-        poll_all_devices();
+      process_discovery(devices);
+      poll_all_devices();
     }
     return;
   }
@@ -66,69 +53,116 @@ void ZigbeeProvider::handle_message(const QString &topic,
     return;
   }
 
-  // If it's not a command and not in the bridge namespace, it's a device update
   if (doc.isObject()) {
     route_update(rel_topic, doc.object());
   }
 }
+
 /**
- * @brief Processes a discovery payload from Zigbee2MQTT and registers new
- * devices.
- *
- * Iterates the provided array of device descriptors, ignoring coordinator
- * entries and entries without an `ieee_address` or already-registered devices.
- * For each newly created device the provider stores mappings (id → device, name
- * → id), emits `device_discovered`, connects the device's request_command
- * signal so that outgoing commands are published to the MQTT topic
- * "<prefix><device_name>/set", and attaches a cleanup handler that removes
- * mappings and emits `device_removed` when the device is destroyed.
- *
- * @param devices Array of device objects as received from the Zigbee2MQTT
- *                bridge (each object is expected to contain an
- *                `ieee_address` and a `name`/`type` field).
+ * @brief Refactored discovery process to reduce cognitive complexity.
  */
 void ZigbeeProvider::process_discovery(const QJsonArray &devices) {
-  for (const auto data : devices) {
-    auto load = data.toObject();
-    if (load["type"] == "Coordinator") {
+  const QSet<QString> snapshot_ids = extract_snapshot_ids(devices);
+  register_new_devices(devices);
+  reconcile_missing_devices(snapshot_ids);
+}
+
+/**
+ * @brief Extracts all valid IEEE addresses from the device list.
+ */
+QSet<QString> ZigbeeProvider::extract_snapshot_ids(const QJsonArray &devices) {
+  QSet<QString> ids;
+  for (const auto &data : devices) {
+    const auto load = data.toObject();
+    if (load.value("type") == "Coordinator") {
+      continue;
+    }
+    const auto id = load.value("ieee_address").toString();
+    if (!id.isEmpty()) {
+      ids.insert(id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * @brief Registers any device from the list that isn't already known.
+ */
+void ZigbeeProvider::register_new_devices(const QJsonArray &devices) {
+  for (const auto &data : devices) {
+    const auto load = data.toObject();
+    if (load.value("type") == "Coordinator") {
       continue;
     }
 
-    auto id = load["ieee_address"].toString();
-
-    if (id.isEmpty() || this->m_devices.contains(id)) {
+    const auto id = load.value("ieee_address").toString();
+    if (id.isEmpty() || m_devices.contains(id)) {
       continue;
     }
 
-    auto device = DeviceFactory::create_device(load);
-
+    const QPointer<SmartDevice> device = DeviceFactory::create_device(load);
     if (device != nullptr) {
-      m_devices[id] = device;
-      m_name_to_id[device->name()] = device->id();
+      setup_new_device(device);
+    }
+  }
+}
 
-      connect(device, &SmartDevice::request_command, this,
-              [this, device](QJsonObject command) {
-                if (command.contains("state") && command["state"].isBool()) {
-                  command["state"] = command["state"].toBool() ? "ON" : "OFF";
-                }
-                QString topic = mqtt_topic_prefix() + device->name() + "/set";
-                QJsonDocument doc(command);
-                mqtt::message_ptr pubmsg = mqtt::make_message(
-                    topic.toStdString(),
-                    doc.toJson(QJsonDocument::Compact).toStdString());
-                mqtt_client()->publish(pubmsg);
-              });
+/**
+ * @brief Configures a newly created device and connects its signals.
+ */
+void ZigbeeProvider::setup_new_device(const QPointer<SmartDevice> &device) {
+  if (device == nullptr) {
+    return;
+  }
 
-      emit device_discovered(device);
+  const QString id = device->id();
+  const QString name = device->name();
 
-      QString id = device->id();
-      QString name = device->name();
+  m_devices[id] = device;
+  m_name_to_id[name] = id;
 
-      connect(device, &QObject::destroyed, this, [this, id, name] {
-        m_devices.remove(id);
-        m_name_to_id.remove(name);
-        emit device_removed(id);
-      });
+  connect(device.get(), &SmartDevice::request_command, this,
+          [this, device](QJsonObject command) {
+            if (command.contains("state") && command["state"].isBool()) {
+              command["state"] = command["state"].toBool() ? "ON" : "OFF";
+            }
+            const QString topic = mqtt_topic_prefix() + device->name() + "/set";
+            const QJsonDocument doc(command);
+            const mqtt::message_ptr pubmsg = mqtt::make_message(
+                topic.toStdString(),
+                doc.toJson(QJsonDocument::Compact).toStdString());
+            mqtt_client()->publish(pubmsg);
+          });
+
+  emit device_discovered(device);
+
+  connect(device.get(), &QObject::destroyed, this, [this, id, name] {
+    if (m_devices.contains(id)) {
+      m_devices.remove(id);
+      m_name_to_id.remove(name);
+      emit device_removed(id);
+    }
+  });
+}
+
+/**
+ * @brief Removes devices that are no longer present in the snapshot.
+ */
+void ZigbeeProvider::reconcile_missing_devices(
+    const QSet<QString> &snapshot_ids) {
+  auto it = m_devices.begin();
+  while (it != m_devices.end()) {
+    const QString id = it.key();
+    if (!snapshot_ids.contains(id)) {
+      const QPointer<SmartDevice> device = it.value();
+      if (device != nullptr) {
+        m_name_to_id.remove(device->name());
+        device->deleteLater();
+      }
+      it = m_devices.erase(it);
+      emit device_removed(id);
+    } else {
+      ++it;
     }
   }
 }
@@ -136,53 +170,41 @@ void ZigbeeProvider::process_discovery(const QJsonArray &devices) {
 /**
  * @brief Routes an incoming payload to the device identified by its friendly
  * name.
- *
- * If the friendly name maps to a known device and that device exists, forwards
- * the payload to the device's update handler; otherwise does nothing.
- *
- * @param friendly_name Friendly name of the target device (as derived from the
- * MQTT topic).
- * @param payload JSON payload to deliver to the device.
  */
-void ZigbeeProvider::route_update(const QString &friendly_name,
-                                  const QJsonObject &payload) {
+void ZigbeeProvider::route_update(
+    const QString
+        &friendly_name, // NOLINT(bugprone-easily-swappable-parameters)
+    const QJsonObject &payload) {
   if (!m_name_to_id.contains(friendly_name)) {
     return;
   }
-  auto id = m_name_to_id.value(friendly_name);
-  auto device = m_devices.value(id);
+  const QString id = m_name_to_id.value(friendly_name);
+  const QPointer<SmartDevice> device = m_devices.value(id);
 
   if (device != nullptr) {
     device->handle_update(payload);
-  };
+  }
 }
 
 /**
- * @brief Requests Zigbee2MQTT to enumerate devices by publishing to the bridge
- * devices topic.
- *
- * Publishes an empty payload to "<prefix>bridge/devices" via the provider's
- * MQTT client to trigger device discovery.
+ * @brief Requests Zigbee2MQTT to enumerate devices.
  */
 void ZigbeeProvider::on_connected() {
-  QString topic = mqtt_topic_prefix() + "bridge/devices";
+  const QString topic = mqtt_topic_prefix() + "bridge/devices";
   mqtt_client()->publish(mqtt::make_message(topic.toStdString(), "", 1, false));
 }
 
 /**
  * @brief Requests state updates from every known Zigbee device.
- *
- * Iterates stored devices and publishes a {"state": ""} get payload to each
- * device's MQTT "<prefix><device_name>/get" topic; null entries are skipped.
  */
 void ZigbeeProvider::poll_all_devices() {
   for (const auto &device : m_devices) {
     if (device == nullptr) {
       continue;
     }
-    QString topic = mqtt_topic_prefix() + device->name() + "/get";
-    QString payload = R"({"state": ""})";
-    mqtt::message_ptr pubmsg =
+    const QString topic = mqtt_topic_prefix() + device->name() + "/get";
+    const QString payload = R"({"state": ""})";
+    const mqtt::message_ptr pubmsg =
         mqtt::make_message(topic.toStdString(), payload.toStdString());
 
     mqtt_client()->publish(pubmsg);

--- a/src/zigbee_utils.cpp
+++ b/src/zigbee_utils.cpp
@@ -52,17 +52,17 @@ std::optional<ColorTempRange> get_color_temp_range(const QJsonObject &data) {
   }
 
   const auto features_object = features_iterator->toObject();
-  int min = features_object["value_min"].toInt();
-  int max = features_object["value_max"].toInt();
-  int neutral = min + ((max - min) / 2);
+  const int min = features_object["value_min"].toInt();
+  const int max = features_object["value_max"].toInt();
+  const int neutral = min + ((max - min) / 2);
   return ColorTempRange{.min = min, .max = max, .neutral = neutral};
 }
 
 SmartLightParams parse_light_params(const QJsonObject &data) {
-  auto friendly_name = data["friendly_name"].toString();
-  auto ieee_address = data["ieee_address"].toString();
-  auto model_id = data["model_id"].toString();
-  auto color_temp_range = get_color_temp_range(data).value_or(ColorTempRange{});
+  const auto friendly_name = data["friendly_name"].toString();
+  const auto ieee_address = data["ieee_address"].toString();
+  const auto model_id = data["model_id"].toString();
+  const auto color_temp_range = get_color_temp_range(data).value_or(ColorTempRange{});
 
   return SmartLightParams{
       .id = ieee_address,


### PR DESCRIPTION
This PR implements a major architectural refactor to make the core `DeviceManager` and `SmartDevice` classes entirely protocol-agnostic, paving the way for multi-protocol support (e.g., Hue, Matter) and logical grouping via 'Rooms'.

### Key Changes:
1. **Protocol-Blind Devices (`SmartDevice` & `SmartLight`):**
   - Stripped all hardcoded `zigbee2mqtt/` topic logic from device implementations.
   - Renamed Zigbee-specific properties (`ieee_address` -> `id`, `friendly_name` -> `name`).
   - Replaced string-based `send_command` with a protocol-agnostic `request_command(QJsonObject)` signal.

2. **Provider Interfaces (`DeviceProvider` & `MqttMixin`):**
   - Introduced the abstract `DeviceProvider` class to handle protocol-specific device lifecycle and ID mapping.
   - Created `MqttMixin` to provide safe, non-owning access to the MQTT client for protocol modules.

3. **Expert Translation (`ZigbeeProvider`):**
   - Extracted all Zigbee JSON parsing and discovery logic from `DeviceManager` into the new `ZigbeeProvider`.
   - The provider acts as an expert translator, listening for protocol-agnostic commands and converting them into Zigbee MQTT topics (and vice versa).

4. **Streamlined `DeviceManager`:**
   - The manager now simply subscribes to `#` and broadcasts incoming payloads to registered providers.
   - It listens reactively to `device_discovered` and `device_removed` signals from providers to manage the global device list.

This creates a clean separation of concerns: The Manager owns the devices and overall state, while Providers exclusively handle transport and translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  - Device management moved to a provider-based architecture and device identity/properties standardized (friendly_name → name, ieee_address → id, model_id → model).

* **New Features**
  - Automatic device discovery, removal events, and polling for device state.
  - MQTT handles broader topics; providers forward raw messages and emit JSON-based commands.
  - New light controls: brightness and color temperature with structured command requests.

* **Bug Fixes**
  - Improved error reporting, connection logging, and guards against duplicate or null updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->