### PR TITLE
Refactor: Unconditional Zigbee Discovery for Robust Reconciliation

### DIFF
--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -42,8 +42,8 @@ void ZigbeeProvider::handle_message(
       devices = doc.object().value("devices").toArray();
     }
 
+    process_discovery(devices);
     if (!devices.isEmpty()) {
-      process_discovery(devices);
       poll_all_devices();
     }
     return;


### PR DESCRIPTION
## Description
This PR ensures that  is executed regardless of whether the device list is empty. This is essential for the reconciliation logic to correctly remove stale or orphaned devices when they are no longer reported by the Zigbee2MQTT bridge.

## Key Changes
- Moved  outside the emptiness check in .
- This guarantees that  runs even with an empty snapshot, enabling full cleanup of internal state.

## Issue
#16 