### PR TITLE
feat: throw std::runtime_error when MQTT_ADDRESS is not set (#17)

### DIFF
--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -7,9 +7,17 @@
 #include <cstdlib>
 #include <iostream>
 #include <mqtt/async_client.h>
+#include <stdexcept>
 #include <string>
 
-const std::string mqtt_address{std::string(std::getenv("MQTT_ADDRESS"))}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static std::string get_mqtt_address() {
+  const char* address = std::getenv("MQTT_ADDRESS");
+  if(address == nullptr) {
+    throw std::runtime_error("MQTT address has not been set. Please set this as an environment variable and try again");
+  }
+
+  return address;
+};
 
 /**
  * @brief Constructs a DeviceManager and initializes MQTT integration.
@@ -19,7 +27,7 @@ const std::string mqtt_address{std::string(std::getenv("MQTT_ADDRESS"))}; // NOL
  * @param parent QObject ownership parent.
  */
 DeviceManager::DeviceManager(QObject *parent)
-    : QObject(parent), m_client(mqtt_address) {
+    : QObject(parent), m_client(get_mqtt_address()) {
   try {
     m_client.set_callback(*this);
   } catch (...) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 
 #include <QApplication>
-#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 
@@ -37,7 +36,7 @@ int main(int argc, char *argv[]) {
 
     return QApplication::exec();
   } catch (const std::exception &e) {
-    std::cerr << e.what();
+    std::cerr << "[ERROR] Startup failed" << e.what() << '\n';
     return 1;
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,31 +5,39 @@
 #include <iostream>
 
 #include <QApplication>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QDir>
+
+#include <exception>
 
 int main(int argc, char *argv[]) {
-  QApplication app(argc, argv);
-  DeviceManager manager;
-  
-  auto* zigbee = new ZigbeeProvider(manager.mqtt_client(), &manager);
-  manager.register_provider(zigbee);
+  try {
+    QApplication app(argc, argv);
+    DeviceManager manager;
 
-  QFile file(style_path);
-  if(file.open(QFile::ReadOnly | QFile::Text)) {
-    QTextStream stream(&file);
-    app.setStyleSheet(stream.readAll());
-    file.close();
+    auto *zigbee = new ZigbeeProvider(manager.mqtt_client(), // NOLINT
+                                      &manager);             // NOLINT
+    manager.register_provider(zigbee);
+
+    QFile file(style_path);
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+      QTextStream stream(&file);
+      app.setStyleSheet(stream.readAll());
+      file.close();
+    }
+
+    MainWindow window(&manager);
+
+    window.showFullScreen();
+
+    manager.connect_to_broker();
+
+    std::cout << "[SUCCESS] Qt App Initialized. Check your screen!" << '\n';
+
+    return QApplication::exec();
+  } catch (const std::exception &e) {
+    std::cerr << e.what();
+    return 1;
   }
-
-  MainWindow window(&manager);
-
-  window.showFullScreen();
-
-  manager.connect_to_broker();
-
-  std::cout << "[SUCCESS] Qt App Initialized. Check your screen!" << '\n';
-
-  return QApplication::exec();
 }


### PR DESCRIPTION
This PR addresses #17 by ensuring that the `MQTT_ADDRESS` environment variable is checked during initialization. 

A lambda is used to initialize the constant `mqtt_address`, which throws a `std::runtime_error` if the variable is not found. This provides a clear error message instead of causing a crash when initializing `std::string` with `nullptr`. 

Added `#include <stdexcept>` to support the new exception usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now validates MQTT configuration from the environment and exits with a clear error if missing.
  * Added top-level exception handling during application startup to surface errors and prevent silent failures.

* **Other Improvements**
  * UI styling is applied before the main window is created, improving initial visual consistency.
  * Provider initialization order adjusted for a more reliable startup sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->