### PR TITLE
refactor: make DeviceManager header self-contained (#11)

### DIFF
--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -4,6 +4,8 @@
 #include <QObject>
 #include <QList>
 #include <QJsonObject>
+#include <QHash>
+#include <QString>
 #include <mqtt/async_client.h>
 
 #include "smart_device.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
 
     return QApplication::exec();
   } catch (const std::exception &e) {
-    std::cerr << "[ERROR] Startup failed" << e.what() << '\n';
+    std::cerr << "[ERROR] Startup failed: " << e.what() << '\n';
     return 1;
   }
 }


### PR DESCRIPTION
This PR addresses #11 by adding missing includes (`<QHash>`, `<QString>`) to `device_manager.h`. It also includes a small fix for the startup error logging in `main.cpp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message formatting for startup failure notifications, ensuring clearer readability of error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->