### PR TITLE
feat: implement connection lost and reconnect logic (#14)

### DIFF
--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -162,7 +162,7 @@ void DeviceManager::connect_to_broker() {
 
   } catch (const mqtt::exception &exc) {
     qDebug() << "[ERROR] failed to establish MQTT connection"
-             << exc.get_error_str();
+             << QString::fromStdString(exc.get_error_str());
   }
 }
 
@@ -171,25 +171,34 @@ void DeviceManager::notify_providers_connected() {
   // discovery/polling
   for (auto &provider : m_providers) {
     if (provider != nullptr) {
-      provider->on_connected();
+      const QPointer<DeviceProvider> &thread_safe_provider = provider;
+      QMetaObject::invokeMethod(
+          provider,
+          [thread_safe_provider]() {
+            if (thread_safe_provider != nullptr) {
+              thread_safe_provider->on_connected();
+            }
+          },
+          Qt::QueuedConnection);
     }
   }
 }
 
-void DeviceManager::connected(const std::string &/*cause*/) {
+void DeviceManager::connected(const std::string & /*cause*/) {
   try {
-    auto token = m_client.subscribe("#", 1);
+    m_client.subscribe("#", 1);
 
     qDebug() << "[LOG] Connected and subscribed to all topics";
 
     notify_providers_connected();
 
   } catch (const mqtt::exception &exc) {
-    qDebug() << "[ERROR] failed to subscribe to all topics";
+    qDebug() << "[ERROR] failed to subscribe to all topics"
+             << QString::fromStdString(exc.get_error_str());
   }
 }
 
 void DeviceManager::connection_lost(const std::string &cause) {
-  qDebug() << "[LOG] connection lost: " << cause;
+  qDebug() << "[LOG] connection lost: " << QString::fromStdString(cause);
 }
 void DeviceManager::delivery_complete(mqtt::delivery_token_ptr /*token*/) {}

--- a/src/device_manager.cpp
+++ b/src/device_manager.cpp
@@ -1,6 +1,7 @@
 #include "device_manager.h"
 #include "smart_device.h"
 
+#include <QDebug>
 #include <QList>
 #include <QObject>
 #include <QString>
@@ -11,9 +12,10 @@
 #include <string>
 
 static std::string get_mqtt_address() {
-  const char* address = std::getenv("MQTT_ADDRESS");
-  if(address == nullptr) {
-    throw std::runtime_error("MQTT address has not been set. Please set this as an environment variable and try again");
+  const char *address = std::getenv("MQTT_ADDRESS");
+  if (address == nullptr) {
+    throw std::runtime_error("MQTT address has not been set. Please set this "
+                             "as an environment variable and try again");
   }
 
   return address;
@@ -94,8 +96,8 @@ void DeviceManager::on_device_discovered(const QPointer<SmartDevice> &device) {
     std::cout << "Device " << device->name().toStdString()
               << " successfully discovered and added to manager" << "\n";
   } else {
-    std::cout << "Device " << device->name().toStdString() << " (ID: "
-              << id.toStdString() << ") updated in manager" << "\n";
+    std::cout << "Device " << device->name().toStdString()
+              << " (ID: " << id.toStdString() << ") updated in manager" << "\n";
   }
 }
 
@@ -158,23 +160,36 @@ void DeviceManager::connect_to_broker() {
 
     m_client.connect(opts)->wait();
 
-    // Subscribe to all topics so providers can filter what they need
-    m_client.subscribe("#", 1);
-
-    std::cout << "Connected and Subscribed to all topics" << "\n";
-
-    // Notify all providers that we are connected so they can perform
-    // discovery/polling
-    for (auto &provider : m_providers) {
-      if (provider != nullptr) {
-        provider->on_connected();
-      }
-    }
-
   } catch (const mqtt::exception &exc) {
-    std::cerr << "MQTT Exception: " << exc.get_error_str() << "\n";
+    qDebug() << "[ERROR] failed to establish MQTT connection"
+             << exc.get_error_str();
   }
 }
 
-void DeviceManager::connection_lost(const std::string & /*cause*/) {}
+void DeviceManager::notify_providers_connected() {
+  // Notify all providers that we are connected so they can perform
+  // discovery/polling
+  for (auto &provider : m_providers) {
+    if (provider != nullptr) {
+      provider->on_connected();
+    }
+  }
+}
+
+void DeviceManager::connected(const std::string &/*cause*/) {
+  try {
+    auto token = m_client.subscribe("#", 1);
+
+    qDebug() << "[LOG] Connected and subscribed to all topics";
+
+    notify_providers_connected();
+
+  } catch (const mqtt::exception &exc) {
+    qDebug() << "[ERROR] failed to subscribe to all topics";
+  }
+}
+
+void DeviceManager::connection_lost(const std::string &cause) {
+  qDebug() << "[LOG] connection lost: " << cause;
+}
 void DeviceManager::delivery_complete(mqtt::delivery_token_ptr /*token*/) {}

--- a/src/include/device_manager.h
+++ b/src/include/device_manager.h
@@ -1,109 +1,122 @@
 #pragma once
 
-#include <QPointer>
-#include <QObject>
-#include <QList>
-#include <QJsonObject>
 #include <QHash>
+#include <QJsonObject>
+#include <QList>
+#include <QObject>
+#include <QPointer>
 #include <QString>
 #include <mqtt/async_client.h>
 
-#include "smart_device.h"
 #include "device_provider.h"
+#include "smart_device.h"
 
 /**
  * @brief Manages a collection of smart devices and their providers.
- * 
- * DeviceManager acts as a central hub for discovering, tracking, and communicating
- * with smart devices via various providers. It also handles MQTT connection.
+ *
+ * DeviceManager acts as a central hub for discovering, tracking, and
+ * communicating with smart devices via various providers. It also handles MQTT
+ * connection.
  */
 class DeviceManager : public QObject, public virtual mqtt::callback {
-    Q_OBJECT
-    Q_PROPERTY(QList<QPointer<SmartDevice>> devices READ devices NOTIFY devices_changed)
+  Q_OBJECT
+  Q_PROPERTY(
+      QList<QPointer<SmartDevice>> devices READ devices NOTIFY devices_changed)
 
-    public:
-        /**
-         * @brief Construct a DeviceManager.
-         * @param parent Optional QObject parent.
-         */
-        explicit DeviceManager(QObject *parent = nullptr);
+public:
+  /**
+   * @brief Construct a DeviceManager.
+   * @param parent Optional QObject parent.
+   */
+  explicit DeviceManager(QObject *parent = nullptr);
 
-        /**
-         * @brief Register a device provider.
-         * @param provider Pointer to the DeviceProvider to register.
-         */
-        void register_provider(DeviceProvider* provider);
+  /**
+   * @brief Register a device provider.
+   * @param provider Pointer to the DeviceProvider to register.
+   */
+  void register_provider(DeviceProvider *provider);
 
-        /**
-         * @brief Get the internal MQTT client.
-         * @returns Reference to the mqtt::async_client.
-         */
-        mqtt::async_client& mqtt_client() { return m_client; }
+  /**
+   * @brief Get the internal MQTT client.
+   * @returns Reference to the mqtt::async_client.
+   */
+  mqtt::async_client &mqtt_client() { return m_client; }
 
-        /**
-         * @brief Get the list of managed devices.
-         * @returns QList of pointers to managed SmartDevice instances.
-         */
-        [[nodiscard]] QList<QPointer<SmartDevice>> devices() const;
+  /**
+   * @brief Get the list of managed devices.
+   * @returns QList of pointers to managed SmartDevice instances.
+   */
+  [[nodiscard]] QList<QPointer<SmartDevice>> devices() const;
 
-        /**
-         * @brief Get a device by its unique identifier.
-         * @param id Unique identifier of the device.
-         * @returns QPointer to the SmartDevice if found, or null otherwise.
-         */
-        [[nodiscard]] QPointer<SmartDevice> get_device(const QString &id) const;
+  /**
+   * @brief Get a device by its unique identifier.
+   * @param id Unique identifier of the device.
+   * @returns QPointer to the SmartDevice if found, or null otherwise.
+   */
+  [[nodiscard]] QPointer<SmartDevice> get_device(const QString &id) const;
 
-        /**
-         * @brief Called when MQTT connection is lost.
-         * @param cause Reason for connection loss.
-         */
-        void connection_lost(const std::string &cause) override;
+  /**
+   * @brief Called when MQTT connection is lost.
+   * @param cause Reason for connection loss.
+   */
+  void connection_lost(const std::string &cause) override;
 
-        /**
-         * @brief Called when an MQTT message arrives.
-         * @param msg The received MQTT message.
-         */
-        void message_arrived(mqtt::const_message_ptr msg) override;
+  /**
+   * @brief Called when an MQTT message arrives.
+   * @param msg The received MQTT message.
+   */
+  void message_arrived(mqtt::const_message_ptr msg) override;
 
-        /**
-         * @brief Called when MQTT delivery is complete.
-         * @param token Token for the delivered message.
-         */
-        void delivery_complete(mqtt::delivery_token_ptr token) override;
+  /**
+   * @brief Called when MQTT delivery is complete.
+   * @param token Token for the delivered message.
+   */
+  void delivery_complete(mqtt::delivery_token_ptr token) override;
 
-        /**
-         * @brief Establish connection to the MQTT broker.
-         */
-        void connect_to_broker();
+  /**
+   * @brief Establish connection to the MQTT broker.
+   */
+  void connect_to_broker();
 
-    signals:
-        /**
-         * @brief Emitted when the list of managed devices changes.
-         */
-        void devices_changed();
+  /**
+   * @brief  called when the MQTT connection is established
+   * @param cause Reason for connection
+   */
+  void connected(const std::string &cause) override;
 
-        /**
-         * @brief Emitted when a new device is discovered.
-         * @param device Pointer to the newly discovered SmartDevice.
-         */
-        void device_discovered(SmartDevice *device);
+signals:
+  /**
+   * @brief Emitted when the list of managed devices changes.
+   */
+  void devices_changed();
 
-    private slots:
-        /**
-         * @brief Internal slot to handle device discovery from providers.
-         * @param device Pointer to the discovered device.
-         */
-        void on_device_discovered(const QPointer<SmartDevice> &device);
+  /**
+   * @brief Emitted when a new device is discovered.
+   * @param device Pointer to the newly discovered SmartDevice.
+   */
+  void device_discovered(SmartDevice *device);
 
-        /**
-         * @brief Internal slot to handle device removal from providers.
-         * @param id Unique identifier of the removed device.
-         */
-        void on_device_removed(const QString &id);
+private slots:
+  /**
+   * @brief Internal slot to handle device discovery from providers.
+   * @param device Pointer to the discovered device.
+   */
+  void on_device_discovered(const QPointer<SmartDevice> &device);
 
-    private:
-        QList<QPointer<DeviceProvider>> m_providers;
-        QHash<QString, QPointer<SmartDevice>> m_devices;
-        mqtt::async_client m_client;   
+  /**
+   * @brief Internal slot to handle device removal from providers.
+   * @param id Unique identifier of the removed device.
+   */
+  void on_device_removed(const QString &id);
 
+private:
+  QList<QPointer<DeviceProvider>> m_providers;
+  QHash<QString, QPointer<SmartDevice>> m_devices;
+  mqtt::async_client m_client;
+
+  /**
+   * @brief called after establishing connection and connecting to topics to
+   * notify all providers for them to perfom discovery/polling
+   */
+  void notify_providers_connected();
 };


### PR DESCRIPTION
This PR addresses #14 by moving MQTT subscription and provider notification into the `connected()` callback. It also implements `connection_lost()` for better lifecycle management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and reporting for connection failures and lost connections with clearer status messages.

* **Refactor**
  * Reworked MQTT connection and provider-notification flow for more reliable post-connection behaviour and thread-safe callbacks.

* **Chores**
  * Consolidated logging to the application's unified logging mechanism for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->