### PR TITLE
refactor: handle discovery from object in bridge/devices (#19)

### DIFF
--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -40,10 +40,12 @@ void ZigbeeProvider::handle_message(
     if (doc.isArray()) {
       devices = doc.array();
       has_authoritative_snapshot = true;
-    } else if (doc.isObject() && doc.object().contains("devices") &&
-               doc.object().value("devices").isArray()) {
-      devices = doc.object().value("devices").toArray();
-      has_authoritative_snapshot = true;
+    } else if (doc.isObject()) {
+      const auto doc_obj = doc.object();
+      if (doc_obj.contains("devices") && doc_obj.value("devices").isArray()) {
+        devices = doc_obj.value("devices").toArray();
+        has_authoritative_snapshot = true;
+      }
     }
 
     if (!has_authoritative_snapshot) {

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -36,10 +36,18 @@ void ZigbeeProvider::handle_message(
 
   if (rel_topic == "bridge/devices") {
     QJsonArray devices;
+    bool has_authoritative_snapshot = false;
     if (doc.isArray()) {
       devices = doc.array();
-    } else if (doc.isObject()) {
+      has_authoritative_snapshot = true;
+    } else if (doc.isObject() && doc.object().contains("devices") &&
+               doc.object().value("devices").isArray()) {
       devices = doc.object().value("devices").toArray();
+      has_authoritative_snapshot = true;
+    }
+
+    if (!has_authoritative_snapshot) {
+      return;
     }
 
     process_discovery(devices);


### PR DESCRIPTION
This PR addresses #19 by correctly identifying authoritative snapshots when the payload is an object containing a `devices` array. It also introduces a safety check to ensure we only process valid snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for device discovery payloads: only authoritative snapshots (properly structured arrays or objects containing device lists) are processed. Non-conforming payloads are ignored early, reducing false discoveries and improving stability of discovery and polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->