### PR TITLE
fix: refine Zigbee command filtering to avoid false positives (#12)

### DIFF
--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -25,12 +25,11 @@ void ZigbeeProvider::handle_message(
   }
 
   const QString rel_topic = topic.mid(mqtt_topic_prefix().length());
-  const auto segments = rel_topic.split('/');
+  const auto segments = rel_topic.split('/', Qt::SkipEmptyParts);
 
-  if (segments.size() == 2 && segments.last() == "set") {
+  if (!segments.isEmpty() && segments.last() == "set") {
     return;
   }
-
   const QJsonDocument doc = QJsonDocument::fromJson(payload);
   if (doc.isNull()) {
     return;

--- a/src/zigbee_provider.cpp
+++ b/src/zigbee_provider.cpp
@@ -4,6 +4,7 @@
 #include <QJsonDocument>
 #include <QObject>
 #include <QSet>
+#include <QStringList>
 
 /**
  * @brief Create a Zigbee provider bound to an MQTT client and the
@@ -24,8 +25,9 @@ void ZigbeeProvider::handle_message(
   }
 
   const QString rel_topic = topic.mid(mqtt_topic_prefix().length());
+  const auto segments = rel_topic.split('/');
 
-  if (rel_topic.endsWith("/set")) {
+  if (segments.size() == 2 && segments.last() == "set") {
     return;
   }
 


### PR DESCRIPTION
This PR addresses #12 by replacing the simple `endsWith("/set")` check with a more precise segment-based check. This ensures that only true command topics (`device/set`) are ignored, preventing valid state updates from being discarded if a device name ends in "set".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of topic filtering for control messages by using explicit segment-based validation, reducing false matches from trailing or empty segments and making detection of "/set" topics more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->